### PR TITLE
Static casting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,16 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # Location for cmake modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+
+# add in Eigen3
+include(FetchContent)
+FetchContent_Declare(
+  Eigen3
+  GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+  GIT_TAG 3.4.1
+)
+FetchContent_MakeAvailable(Eigen3)
+
 # add in GaussQuad
 include(FetchContent)
 FetchContent_Declare(
@@ -29,7 +39,7 @@ FetchContent_MakeAvailable(NumericConcepts)
 # add in GaussQuad
 FetchContent_Declare(
   GaussQuad
-  GIT_REPOSITORY https://github.com/da380/GaussQuad.git
+  GIT_REPOSITORY git@github.com:da380/GaussQuad.git
   GIT_TAG main
 )
 FetchContent_MakeAvailable(GaussQuad)
@@ -52,6 +62,7 @@ target_link_libraries(GSHTrans INTERFACE
   NumericConcepts
   FFTWpp
   GaussQuad
+  Eigen3::Eigen
   OpenMP::OpenMP_CXX)
 target_include_directories (GaussQuad INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansionBase.h
+++ b/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansionBase.h
@@ -83,7 +83,7 @@ class CanonicalComponentExpansionBase {
   requires Writeable::value && std::same_as<typename __Derived::Scalar, Scalar>
   auto& operator=(const CanonicalComponentExpansionBase<_N, __Derived>& other) {
     assert(other.MaxDegree() == this->MaxDegree());
-    for (auto [l, m] : this->Indices()) {
+    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
       operator[](l, m) = other[l, m];
     }
     return Derived();
@@ -102,7 +102,7 @@ class CanonicalComponentExpansionBase {
   auto& operator+=(
       const CanonicalComponentExpansionBase<_N, __Derived>& other) {
     assert(other.MaxDegree() == this->MaxDegree());
-    for (auto [l, m] : this->Indices()) {
+    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
       operator[](l, m) += other[l, m];
     }
     return Derived();
@@ -121,7 +121,7 @@ class CanonicalComponentExpansionBase {
   auto& operator-=(
       const CanonicalComponentExpansionBase<_N, __Derived>& other) {
     assert(other.MaxDegree() == this->MaxDegree());
-    for (auto [l, m] : this->Indices()) {
+    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
       operator[](l, m) -= other(l, m);
     }
     return Derived();
@@ -138,7 +138,7 @@ class CanonicalComponentExpansionBase {
   auto& operator*=(Scalar s)
   requires Writeable::value
   {
-    for (auto [l, m] : this->Indices()) {
+    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
       operator[](l, m) *= s;
     }
     return Derived();
@@ -148,7 +148,7 @@ class CanonicalComponentExpansionBase {
   auto& operator/=(Scalar s)
   requires Writeable::value
   {
-    for (auto [l, m] : this->Indices()) {
+    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
       operator[](l, m) /= s;
     }
     return Derived();


### PR DESCRIPTION
Code wouldn't compile with gcc15.2. The issue is that in CanonicalComponentExpansionBase.h the derived method was called via this->Indices(). 

According to Gemini: The compiler is telling you that CanonicalComponentExpansionBase has no method called Indices. This is correct; the Indices method actually belongs to the _Derived class.

The reason it worked in GCC 13.2 was likely due to a more lenient (but technically incorrect) name lookup. The newer GCC 15.2 is stricter and correctly enforces the rule that you must be explicit when a base class calls a derived class's methods in this pattern.

Replaced with 
```bash
static_cast<_Derived*>(this)->Indices()
```
