### PR TITLE
Few fixes from codex

### DIFF
--- a/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansion.h
+++ b/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansion.h
@@ -3,10 +3,10 @@
 
 #include <FFTWpp/Core>
 #include <algorithm>
-#include <cassert>
 #include <concepts>
 #include <cstddef>
 #include <ranges>
+#include <stdexcept>
 #include <type_traits>
 
 #include "../Concepts.h"
@@ -116,7 +116,10 @@ class CanonicalComponentExpansion
   FFTWpp::vector<Complex> _data;
 
   auto& AssignValues(const CanonicalComponentExpansion& other) {
-    assert(other.Size() == Size());
+    if (other.Size() != Size()) {
+      throw std::invalid_argument(
+          "Cannot assign canonical component expansions with different sizes");
+    }
     std::ranges::copy(other._data, _data.begin());
     return *this;
   }

--- a/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansion.h
+++ b/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansion.h
@@ -1,8 +1,12 @@
 #ifndef GSH_TRANS_CANONICAL_COMPONENT_EXPANSION_GUARD_H
 #define GSH_TRANS_CANONICAL_COMPONENT_EXPANSION_GUARD_H
 
+#include <FFTWpp/Core>
+#include <algorithm>
+#include <cassert>
 #include <concepts>
-#include <format>
+#include <cstddef>
+#include <ranges>
 #include <type_traits>
 
 #include "../Concepts.h"
@@ -10,12 +14,10 @@
 
 namespace GSHTrans {
 
-// Forward declare class.
 template <std::ptrdiff_t _N, typename _Grid, RealOrComplexValued _Value>
 requires std::derived_from<_Grid, GridBase<_Grid>>
 class CanonicalComponentExpansion;
 
-// Set traits.
 namespace Internal {
 
 template <std::ptrdiff_t _N, typename _Grid, RealOrComplexValued _Value>
@@ -24,10 +26,13 @@ struct Traits<CanonicalComponentExpansion<_N, _Grid, _Value>> {
   using Value = _Value;
   using Real = typename _Grid::Real;
   using Complex = typename _Grid::Complex;
-  using Scalar =
-      std::conditional_t<std::same_as<Value, RealValued>, Real, Complex>;
-  using MRange = typename std::conditional_t<std::same_as<Value, RealValued>,
-                                             NonNegative, All>;
+
+  // RealValued describes real grid samples represented by the reduced m >= 0
+  // spectrum. Its stored coefficients remain complex; negative Fourier modes
+  // are implicit and are related to the expansion at -n by GSH symmetry.
+  using Scalar = Complex;
+  using MRange =
+      std::conditional_t<std::same_as<Value, RealValued>, NonNegative, All>;
   using Writeable = std::true_type;
 };
 
@@ -37,105 +42,86 @@ template <std::ptrdiff_t _N, typename _Grid, RealOrComplexValued _Value>
 requires std::derived_from<_Grid, GridBase<_Grid>>
 class CanonicalComponentExpansion
     : public CanonicalComponentExpansionBase<
-          _N, CanonicalComponentExpansion<_N, _Grid, _Value>>,
-      public GSHIndices<std::conditional_t<std::same_as<_Value, RealValued>,
-                                           NonNegative, All>> {
+          _N, CanonicalComponentExpansion<_N, _Grid, _Value>> {
  public:
-  using Value = typename Internal::Traits<
-      CanonicalComponentExpansion<_N, _Grid, _Value>>::Value;
-  using Int = typename Internal::Traits<
-      CanonicalComponentExpansion<_N, _Grid, _Value>>::Int;
-  using Real = typename Internal::Traits<
-      CanonicalComponentExpansion<_N, _Grid, _Value>>::Real;
-  using Complex = typename Internal::Traits<
-      CanonicalComponentExpansion<_N, _Grid, _Value>>::Complex;
-  using Scalar = typename Internal::Traits<
-      CanonicalComponentExpansion<_N, _Grid, _Value>>::Scalar;
-  using MRange = typename Internal::Traits<
-      CanonicalComponentExpansion<_N, _Grid, _Value>>::MRange;
-  using Writeable = typename Internal::Traits<
-      CanonicalComponentExpansion<_N, _Grid, _Value>>::Writeable;
+  using Self = CanonicalComponentExpansion<_N, _Grid, _Value>;
+  using Base = CanonicalComponentExpansionBase<_N, Self>;
+  using Traits = Internal::Traits<Self>;
+  using Value = typename Traits::Value;
+  using Int = typename Traits::Int;
+  using Real = typename Traits::Real;
+  using Complex = typename Traits::Complex;
+  using Scalar = typename Traits::Scalar;
+  using MRange = typename Traits::MRange;
+  using Writeable = typename Traits::Writeable;
 
-  // Return the grid.
   auto& Grid() const { return _grid; }
 
-  // Read access to data.
-  auto operator[](Int l, Int m) const { return _data[this->Index(l, m)]; }
+  auto MinDegree() const { return _indices.MinDegree(); }
+  auto MaxDegree() const { return _indices.MaxDegree(); }
+  auto MaxOrder() const { return _indices.MaxOrder(); }
+  auto Degrees() const { return _indices.Degrees(); }
+  auto Indices() const { return _indices.Indices(); }
+  auto Orders() const { return Indices() | std::ranges::views::values; }
+  auto Size() const { return _indices.Size(); }
+  auto Index(Int l, Int m) const { return _indices.Index(l, m); }
 
-  // Write access to data.
-  auto& operator[](Int l, Int m) { return _data[this->Index(l, m)]; }
+  auto operator[](Int l, Int m) const { return _data[Index(l, m)]; }
+  auto& operator[](Int l, Int m) { return _data[Index(l, m)]; }
 
-  // Return a view to the data.
   auto Data() { return std::ranges::views::all(_data); }
+  auto Data() const { return std::ranges::views::all(_data); }
 
-  // Default constructor.
-  CanonicalComponentExpansion() = default;
+  CanonicalComponentExpansion() = delete;
 
-  // Construct from grid initialising values to zero.
-  CanonicalComponentExpansion(_Grid& grid)
-      : GSHIndices<MRange>(grid.MaxDegree(), grid.MaxDegree(), _N),
-        _grid{grid},
-        _data{FFTWpp::vector<Complex>(this->Size())} {}
+  explicit CanonicalComponentExpansion(_Grid& grid)
+      : _grid{grid},
+        _indices{grid.MaxDegree(), grid.MaxDegree(), _N},
+        _data{FFTWpp::vector<Complex>(_indices.Size())} {}
 
-  /*
-
-
-
-  // Default constructor.
-  CanonicalComponentExpansion() = default;
-
-  // Construct from grid initialising values to zero.
-  CanonicalComponentExpansion(_Grid& grid)
-      : _grid{grid}, _data{FFTWpp::vector<Scalar>(this->ExpansionSize())} {}
-
-  // Construction from grid initialising values with a function.
-  template <typename Function>
-  requires ScalarFunctionS2<Function, Real, Scalar>
-  CanonicalComponentExpansion(_Grid& grid, Function&& f)
-      : CanonicalComponentExpansion(grid) {
-    std::ranges::copy(_grid.ProjectFunction(f), _data.begin());
-  }
-
-  // Construct from an element of the base class.
   template <typename Derived>
-  requires std::convertible_to<typename Derived::Scalar, Scalar>
+  requires std::same_as<typename Derived::Scalar, Scalar> &&
+           std::same_as<typename Derived::MRange, MRange>
   CanonicalComponentExpansion(
       const CanonicalComponentExpansionBase<_N, Derived>& other)
-      : CanonicalComponentExpansion(other.UpperIndex(), other.Grid()) {
-    for (auto [iTheta, iPhi] : this->PointIndices()) {
-      operator[](iTheta, iPhi) = other[iTheta, iPhi];
+      : CanonicalComponentExpansion(other.Grid()) {
+    for (auto [l, m] : Indices()) {
+      operator[](l, m) = other[l, m];
     }
   }
 
   template <typename Derived>
-  requires std::convertible_to<typename Derived::Scalar, Scalar>
+  requires std::same_as<typename Derived::Scalar, Scalar> &&
+           std::same_as<typename Derived::MRange, MRange>
   CanonicalComponentExpansion(
       CanonicalComponentExpansionBase<_N, Derived>&& other)
       : CanonicalComponentExpansion(other) {}
 
-  // Default copy and move constructors.
   CanonicalComponentExpansion(const CanonicalComponentExpansion&) = default;
   CanonicalComponentExpansion(CanonicalComponentExpansion&&) = default;
 
-  // Default copy and move assignment.
-  CanonicalComponentExpansion& operator=(const CanonicalComponentExpansion&)
-  = default; CanonicalComponentExpansion&
-  operator=(CanonicalComponentExpansion&&) = default;
+  CanonicalComponentExpansion& operator=(
+      const CanonicalComponentExpansion& other) {
+    return AssignValues(other);
+  }
+  CanonicalComponentExpansion& operator=(CanonicalComponentExpansion&& other) {
+    return AssignValues(other);
+  }
 
-  // Use assignment defined in base class.
-  using CanonicalComponentExpansionBase<
-      _N, CanonicalComponentExpansion<_N, _Grid, _Value>>::operator=;
-
-*/
+  using Base::operator=;
 
  private:
   _Grid& _grid;
+  GSHIndices<MRange> _indices;
   FFTWpp::vector<Complex> _data;
+
+  auto& AssignValues(const CanonicalComponentExpansion& other) {
+    assert(other.Size() == Size());
+    std::ranges::copy(other._data, _data.begin());
+    return *this;
+  }
 };
 
-/*
-
-// Type aliases for real and complex Expansions.
 template <std::ptrdiff_t N, typename Grid>
 requires std::derived_from<Grid, GridBase<Grid>>
 using RealCanonicalComponentExpansion =
@@ -146,21 +132,19 @@ requires std::derived_from<Grid, GridBase<Grid>>
 using ComplexCanonicalComponentExpansion =
     CanonicalComponentExpansion<N, Grid, ComplexValued>;
 
-// Type aliases for scalar Expansions.
 template <typename Grid, RealOrComplexValued Value>
 requires std::derived_from<Grid, GridBase<Grid>>
 using ScalarExpansion = CanonicalComponentExpansion<0, Grid, Value>;
 
 template <typename Grid>
 requires std::derived_from<Grid, GridBase<Grid>>
-using RealScalarExpansion = CanonicalComponentExpansion<0, Grid, RealValued>;
+using RealScalarExpansion =
+    CanonicalComponentExpansion<0, Grid, RealValued>;
 
 template <typename Grid>
 requires std::derived_from<Grid, GridBase<Grid>>
 using ComplexScalarExpansion =
     CanonicalComponentExpansion<0, Grid, ComplexValued>;
-
-*/
 
 }  // namespace GSHTrans
 

--- a/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansionBase.h
+++ b/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansionBase.h
@@ -1,7 +1,6 @@
 #ifndef GSH_TRANS_CANONICAL_COMPONENT_EXPANSION_BASE_GUARD_H
 #define GSH_TRANS_CANONICAL_COMPONENT_EXPANSION_BASE_GUARD_H
 
-#include <cassert>
 #include <concepts>
 #include <cstddef>
 #include <stdexcept>
@@ -49,10 +48,7 @@ class CanonicalComponentExpansionBase {
            std::same_as<typename __Derived::Scalar, Scalar> &&
            std::same_as<typename __Derived::MRange, MRange>
   auto& operator=(const CanonicalComponentExpansionBase<_N, __Derived>& other) {
-    if (other.Size() != Size()) {
-      throw std::invalid_argument(
-          "Cannot assign canonical component expansions with different sizes");
-    }
+    RequireSameSize(other);
     for (auto [l, m] : Indices()) {
       operator[](l, m) = other[l, m];
     }
@@ -73,7 +69,7 @@ class CanonicalComponentExpansionBase {
            std::same_as<typename __Derived::MRange, MRange>
   auto& operator+=(
       const CanonicalComponentExpansionBase<_N, __Derived>& other) {
-    assert(other.MaxDegree() == MaxDegree());
+    RequireSameSize(other);
     for (auto [l, m] : Indices()) {
       operator[](l, m) += other[l, m];
     }
@@ -94,7 +90,7 @@ class CanonicalComponentExpansionBase {
            std::same_as<typename __Derived::MRange, MRange>
   auto& operator-=(
       const CanonicalComponentExpansionBase<_N, __Derived>& other) {
-    assert(other.MaxDegree() == MaxDegree());
+    RequireSameSize(other);
     for (auto [l, m] : Indices()) {
       operator[](l, m) -= other[l, m];
     }
@@ -128,6 +124,15 @@ class CanonicalComponentExpansionBase {
   }
 
  private:
+  template <typename __Derived>
+  void RequireSameSize(
+      const CanonicalComponentExpansionBase<_N, __Derived>& other) const {
+    if (other.Size() != Size()) {
+      throw std::invalid_argument(
+          "Canonical component expansions must have the same size");
+    }
+  }
+
   constexpr auto& Derived() const {
     return static_cast<const _Derived&>(*this);
   }

--- a/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansionBase.h
+++ b/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansionBase.h
@@ -1,10 +1,9 @@
 #ifndef GSH_TRANS_CANONICAL_COMPONENT_EXPANSION_BASE_GUARD_H
 #define GSH_TRANS_CANONICAL_COMPONENT_EXPANSION_BASE_GUARD_H
 
+#include <cassert>
 #include <concepts>
-#include <format>
-#include <iostream>
-#include <type_traits>
+#include <cstddef>
 
 #include "../Concepts.h"
 #include "../GridBase.h"
@@ -23,174 +22,112 @@ class CanonicalComponentExpansionBase {
   using MRange = typename Internal::Traits<_Derived>::MRange;
   using Writeable = typename Internal::Traits<_Derived>::Writeable;
 
-  // Return the Upper Index
-  auto UpperIndex() const { return _N; }
+  constexpr auto UpperIndex() const { return _N; }
 
-  // Minimum degree.
   auto MinDegree() const { return Derived().MinDegree(); }
-
-  // Maximum degree.
   auto MaxDegree() const { return Derived().MaxDegree(); }
-
-  // Return the degrees.
+  auto MaxOrder() const { return Derived().MaxOrder(); }
   auto Degrees() const { return Derived().Degrees(); }
-
-  // Return the spherical harmonic indices.
-  // auto Indices() const { return Derived().Indices(); }
-
-  // Return the data index for the (l,m)th value.
+  auto Indices() const { return Derived().Indices(); }
+  auto Orders() const { return Derived().Orders(); }
+  auto Size() const { return Derived().Size(); }
   auto Index(Int l, Int m) const { return Derived().Index(l, m); }
 
-  // Return the grid.
   auto& Grid() const { return Derived().Grid(); }
 
-  // Return spherical harmonic indices.
-  // auto Indices() const {
-  //  return GSHIndices<MRange>(this->MaxDegree(), this->MaxDegree(), _N)
-  //      .Indices();
-  // }
-
-  // Return the index for the (l,m)th coefficient.
-  // auto Index(Int l, Int m) const {
-  //  return GSHIndices<MRange>(this->MaxDegree(), this->MaxDegree(), _N)
-  //      .Index(l, m);
-  // }
-
-  // Return the spherical harmonic degree for each datum.
-  // auto Degrees() const { return Indices() | std::ranges::views::keys; }
-
-  // Return the spherical harmonic order for each datum.
-  // auto Orders() const { return Indices() | std::ranges::views::values; }
-
-  // Return the total number of coefficients.
-  // auto Size() const {
-  /// return GSHIndices<MRange>(this->MaxDegree(), this->MaxDegree(),
-  /// _N).Size();
-  // }
-
-  // Read access to data.
   auto operator[](Int l, Int m) const { return Derived()[l, m]; }
 
-  // Write access to data.
   auto& operator[](Int l, Int m)
   requires Writeable::value
   {
     return Derived()[l, m];
   }
 
-  // Assign values from another Expansion.
   template <typename __Derived>
-  requires Writeable::value && std::same_as<typename __Derived::Scalar, Scalar>
+  requires Writeable::value &&
+           std::same_as<typename __Derived::Scalar, Scalar> &&
+           std::same_as<typename __Derived::MRange, MRange>
   auto& operator=(const CanonicalComponentExpansionBase<_N, __Derived>& other) {
-    assert(other.MaxDegree() == this->MaxDegree());
-    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
+    assert(other.MaxDegree() == MaxDegree());
+    for (auto [l, m] : Indices()) {
       operator[](l, m) = other[l, m];
     }
     return Derived();
   }
 
   template <typename __Derived>
-  requires Writeable::value && std::same_as<typename __Derived::Scalar, Scalar>
+  requires Writeable::value &&
+           std::same_as<typename __Derived::Scalar, Scalar> &&
+           std::same_as<typename __Derived::MRange, MRange>
   auto& operator=(CanonicalComponentExpansionBase<_N, __Derived>&& other) {
-    Derived() = other;
-    return Derived();
+    return operator=(other);
   }
 
-  // Compound plus assignment with other Expansion.
   template <typename __Derived>
-  requires Writeable::value && std::same_as<typename __Derived::Scalar, Scalar>
+  requires Writeable::value &&
+           std::same_as<typename __Derived::Scalar, Scalar> &&
+           std::same_as<typename __Derived::MRange, MRange>
   auto& operator+=(
       const CanonicalComponentExpansionBase<_N, __Derived>& other) {
-    assert(other.MaxDegree() == this->MaxDegree());
-    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
+    assert(other.MaxDegree() == MaxDegree());
+    for (auto [l, m] : Indices()) {
       operator[](l, m) += other[l, m];
     }
     return Derived();
   }
 
   template <typename __Derived>
-  requires Writeable::value && std::same_as<typename __Derived::Scalar, Scalar>
+  requires Writeable::value &&
+           std::same_as<typename __Derived::Scalar, Scalar> &&
+           std::same_as<typename __Derived::MRange, MRange>
   auto& operator+=(CanonicalComponentExpansionBase<_N, __Derived>&& other) {
-    Derived() += other;
-    return Derived();
+    return operator+=(other);
   }
 
-  // Compound minus assignment with other Expansion.
   template <typename __Derived>
-  requires Writeable::value && std::same_as<typename __Derived::Scalar, Scalar>
+  requires Writeable::value &&
+           std::same_as<typename __Derived::Scalar, Scalar> &&
+           std::same_as<typename __Derived::MRange, MRange>
   auto& operator-=(
       const CanonicalComponentExpansionBase<_N, __Derived>& other) {
-    assert(other.MaxDegree() == this->MaxDegree());
-    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
-      operator[](l, m) -= other(l, m);
+    assert(other.MaxDegree() == MaxDegree());
+    for (auto [l, m] : Indices()) {
+      operator[](l, m) -= other[l, m];
     }
     return Derived();
   }
 
   template <typename __Derived>
-  requires Writeable::value && std::same_as<typename __Derived::Scalar, Scalar>
+  requires Writeable::value &&
+           std::same_as<typename __Derived::Scalar, Scalar> &&
+           std::same_as<typename __Derived::MRange, MRange>
   auto& operator-=(CanonicalComponentExpansionBase<_N, __Derived>&& other) {
-    Derived() -= other;
-    return Derived();
+    return operator-=(other);
   }
 
-  // Compound multiply assignment with scalar.
-  auto& operator*=(Scalar s)
+  auto& operator*=(Scalar scalar)
   requires Writeable::value
   {
-    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
-      operator[](l, m) *= s;
+    for (auto [l, m] : Indices()) {
+      operator[](l, m) *= scalar;
     }
     return Derived();
   }
 
-  // Compound divide assignment with scalar.
-  auto& operator/=(Scalar s)
+  auto& operator/=(Scalar scalar)
   requires Writeable::value
   {
-    for (auto [l, m] : static_cast<_Derived*>(this)->Indices()) {
-      operator[](l, m) /= s;
+    for (auto [l, m] : Indices()) {
+      operator[](l, m) /= scalar;
     }
     return Derived();
   }
-
-  // Write values to ostream.
-  /*
-  friend std::ostream& operator<<(
-      std::ostream& os,
-      const CanonicalComponentExpansionBase<_N, _Derived>& u) {
-    auto values = u.Indices() | std::ranges::views::transform([&u](auto pair) {
-                    auto [l, m] = pair;
-                    return u[l, m];
-                  });
-    auto range = std::ranges::views::zip(u.Degrees(), u.Orders(), values);
-    auto n = u.Size();
-    auto printValues = [&os](auto l, auto m, auto val, auto newLine) {
-      os << std::format("{:+8}  {:+8}  ({:+.8e},  {:+.8e})", l, m, val.real(),
-                        val.imag());
-      if (newLine) os << '\n';
-    };
-    for (auto [l, m, val] : range | std::ranges::views::take(n - 1)) {
-      printValues(l, m, val, true);
-    }
-    for (auto [l, m, val] : range | std::ranges::views::drop(n - 1)) {
-      printValues(l, m, val, false);
-    }
-    return os;
-  }
-*/
 
  private:
   constexpr auto& Derived() const {
     return static_cast<const _Derived&>(*this);
   }
   constexpr auto& Derived() { return static_cast<_Derived&>(*this); }
-
-  // Return the GSHIndex.
-  auto GSHIndex() const {
-    return std::move(
-        GSHIndices<MRange>(this->MaxDegree(), this->MaxDegree(), _N));
-  }
 };
 
 }  // namespace GSHTrans

--- a/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansionBase.h
+++ b/GSHTrans/src/CanonicalComponentExpansion/CanonicalComponentExpansionBase.h
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <concepts>
 #include <cstddef>
+#include <stdexcept>
 
 #include "../Concepts.h"
 #include "../GridBase.h"
@@ -48,7 +49,10 @@ class CanonicalComponentExpansionBase {
            std::same_as<typename __Derived::Scalar, Scalar> &&
            std::same_as<typename __Derived::MRange, MRange>
   auto& operator=(const CanonicalComponentExpansionBase<_N, __Derived>& other) {
-    assert(other.MaxDegree() == MaxDegree());
+    if (other.Size() != Size()) {
+      throw std::invalid_argument(
+          "Cannot assign canonical component expansions with different sizes");
+    }
     for (auto [l, m] : Indices()) {
       operator[](l, m) = other[l, m];
     }

--- a/GSHTrans/src/CanonicalComponentField/CanonicalComponentField.h
+++ b/GSHTrans/src/CanonicalComponentField/CanonicalComponentField.h
@@ -2,6 +2,8 @@
 #define GSH_TRANS_CANONICAL_COMPONENT_FIELD_GUARD_H
 
 #include <FFTWpp/Core>
+#include <algorithm>
+#include <cassert>
 #include <concepts>
 #include <cstddef>
 #include <iostream>
@@ -73,8 +75,8 @@ class CanonicalComponentField
   // Return a view to the data.
   auto Data() { return std::ranges::views::all(_data); }
 
-  // Default constructor.
-  CanonicalComponentField() = default;
+  // A field must always refer to a grid.
+  CanonicalComponentField() = delete;
 
   // Construct from grid initialising values to zero.
   CanonicalComponentField(_Grid& grid)
@@ -92,7 +94,7 @@ class CanonicalComponentField
   template <typename Derived>
   requires std::convertible_to<typename Derived::Scalar, Scalar>
   CanonicalComponentField(const CanonicalComponentFieldBase<_N, Derived>& other)
-      : CanonicalComponentField(other.UpperIndex(), other.Grid()) {
+      : CanonicalComponentField(other.Grid()) {
     for (auto [iTheta, iPhi] : this->PointIndices()) {
       operator[](iTheta, iPhi) = other[iTheta, iPhi];
     }
@@ -107,9 +109,13 @@ class CanonicalComponentField
   CanonicalComponentField(const CanonicalComponentField&) = default;
   CanonicalComponentField(CanonicalComponentField&&) = default;
 
-  // Default copy and move assignment.
-  CanonicalComponentField& operator=(const CanonicalComponentField&) = default;
-  CanonicalComponentField& operator=(CanonicalComponentField&&) = default;
+  // Assignment copies values while retaining this field's grid.
+  CanonicalComponentField& operator=(const CanonicalComponentField& other) {
+    return AssignValues(other);
+  }
+  CanonicalComponentField& operator=(CanonicalComponentField&& other) {
+    return AssignValues(other);
+  }
 
   // Use assignment defined in base class.
   using CanonicalComponentFieldBase<
@@ -121,6 +127,12 @@ class CanonicalComponentField
 
   auto Index(Int iTheta, int iPhi) const {
     return iTheta * this->NumberOfLongitudes() + iPhi;
+  }
+
+  auto& AssignValues(const CanonicalComponentField& other) {
+    assert(other.Size() == this->Size());
+    std::ranges::copy(other._data, _data.begin());
+    return *this;
   }
 };
 

--- a/GSHTrans/src/CanonicalComponentField/CanonicalComponentField.h
+++ b/GSHTrans/src/CanonicalComponentField/CanonicalComponentField.h
@@ -3,11 +3,11 @@
 
 #include <FFTWpp/Core>
 #include <algorithm>
-#include <cassert>
 #include <concepts>
 #include <cstddef>
 #include <iostream>
 #include <limits>
+#include <stdexcept>
 #include <vector>
 
 #include "../Concepts.h"
@@ -130,7 +130,10 @@ class CanonicalComponentField
   }
 
   auto& AssignValues(const CanonicalComponentField& other) {
-    assert(other.Size() == this->Size());
+    if (other.Size() != this->Size()) {
+      throw std::invalid_argument(
+          "Cannot assign canonical component fields with different sizes");
+    }
     std::ranges::copy(other._data, _data.begin());
     return *this;
   }

--- a/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldBase.h
+++ b/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldBase.h
@@ -4,6 +4,7 @@
 #include <concepts>
 #include <format>
 #include <iostream>
+#include <stdexcept>
 
 #include "../Concepts.h"
 #include "../FieldBase.h"
@@ -50,7 +51,10 @@ class CanonicalComponentFieldBase
   requires Writeable::value &&
            std::convertible_to<typename __Derived::Scalar, Scalar>
   auto& operator=(const CanonicalComponentFieldBase<_N, __Derived>& other) {
-    assert(other.Size() == Size());
+    if (other.Size() != Size()) {
+      throw std::invalid_argument(
+          "Cannot assign canonical component fields with different sizes");
+    }
     for (auto [iTheta, iPhi] : this->PointIndices()) {
       operator[](iTheta, iPhi) = other[iTheta, iPhi];
     }

--- a/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldBase.h
+++ b/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldBase.h
@@ -51,10 +51,7 @@ class CanonicalComponentFieldBase
   requires Writeable::value &&
            std::convertible_to<typename __Derived::Scalar, Scalar>
   auto& operator=(const CanonicalComponentFieldBase<_N, __Derived>& other) {
-    if (other.Size() != Size()) {
-      throw std::invalid_argument(
-          "Cannot assign canonical component fields with different sizes");
-    }
+    RequireSameSize(other);
     for (auto [iTheta, iPhi] : this->PointIndices()) {
       operator[](iTheta, iPhi) = other[iTheta, iPhi];
     }
@@ -74,7 +71,7 @@ class CanonicalComponentFieldBase
   requires Writeable::value &&
            std::convertible_to<typename __Derived::Scalar, Scalar>
   auto& operator+=(const CanonicalComponentFieldBase<_N, __Derived>& other) {
-    assert(other.Size() == Size());
+    RequireSameSize(other);
     for (auto [iTheta, iPhi] : this->PointIndices()) {
       operator[](iTheta, iPhi) += other[iTheta, iPhi];
     }
@@ -104,7 +101,7 @@ class CanonicalComponentFieldBase
   requires Writeable::value &&
            std::convertible_to<typename __Derived::Scalar, Scalar>
   auto& operator-=(const CanonicalComponentFieldBase<_N, __Derived>& other) {
-    assert(other.Size() == Size());
+    RequireSameSize(other);
     for (auto [iTheta, iPhi] : this->PointIndices()) {
       operator[](iTheta, iPhi) -= other[iTheta, iPhi];
     }
@@ -134,7 +131,7 @@ class CanonicalComponentFieldBase
   requires Writeable::value &&
            std::convertible_to<typename __Derived::Scalar, Scalar>
   auto& operator*=(const CanonicalComponentFieldBase<_N, __Derived>& other) {
-    assert(other.Size() == Size());
+    RequireSameSize(other);
     for (auto [iTheta, iPhi] : this->PointIndices()) {
       operator[](iTheta, iPhi) *= other[iTheta, iPhi];
     }
@@ -164,7 +161,7 @@ class CanonicalComponentFieldBase
   requires Writeable::value &&
            std::convertible_to<typename __Derived::Scalar, Scalar>
   auto& operator/=(const CanonicalComponentFieldBase<_N, __Derived>& other) {
-    assert(other.Size() == Size());
+    RequireSameSize(other);
     for (auto [iTheta, iPhi] : this->PointIndices()) {
       operator[](iTheta, iPhi) /= other[iTheta, iPhi];
     }
@@ -219,6 +216,15 @@ class CanonicalComponentFieldBase
   }
 
  private:
+  template <typename OtherDerived>
+  void RequireSameSize(
+      const CanonicalComponentFieldBase<_N, OtherDerived>& other) const {
+    if (other.Size() != Size()) {
+      throw std::invalid_argument(
+          "Canonical component fields must have the same size");
+    }
+  }
+
   constexpr auto& Derived() const {
     return static_cast<const _Derived&>(*this);
   }

--- a/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldBase.h
+++ b/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldBase.h
@@ -102,7 +102,7 @@ class CanonicalComponentFieldBase
   auto& operator-=(const CanonicalComponentFieldBase<_N, __Derived>& other) {
     assert(other.Size() == Size());
     for (auto [iTheta, iPhi] : this->PointIndices()) {
-      operator[](iTheta, iPhi) -= other(iTheta, iPhi);
+      operator[](iTheta, iPhi) -= other[iTheta, iPhi];
     }
     return Derived();
   }
@@ -132,7 +132,7 @@ class CanonicalComponentFieldBase
   auto& operator*=(const CanonicalComponentFieldBase<_N, __Derived>& other) {
     assert(other.Size() == Size());
     for (auto [iTheta, iPhi] : this->PointIndices()) {
-      operator[](iTheta, iPhi) *= other(iTheta, iPhi);
+      operator[](iTheta, iPhi) *= other[iTheta, iPhi];
     }
     return Derived();
   }
@@ -162,7 +162,7 @@ class CanonicalComponentFieldBase
   auto& operator/=(const CanonicalComponentFieldBase<_N, __Derived>& other) {
     assert(other.Size() == Size());
     for (auto [iTheta, iPhi] : this->PointIndices()) {
-      operator[](iTheta, iPhi) /= other(iTheta, iPhi);
+      operator[](iTheta, iPhi) /= other[iTheta, iPhi];
     }
     return Derived();
   }

--- a/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldUnary.h
+++ b/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldUnary.h
@@ -29,19 +29,19 @@ class CanonicalComponentFieldImag;
 
 template <std::ptrdiff_t N, typename Derived, typename Function>
 requires requires() {
-  requires std::invocable<Function, typename Derived::Scalar>;
+  requires std::invocable<const Function&, typename Derived::Scalar>;
   requires std::convertible_to<
-      std::invoke_result_t<Function, typename Derived::Scalar>,
+      std::invoke_result_t<const Function&, typename Derived::Scalar>,
       typename Derived::Scalar>;
 }
 class CanonicalComponentFieldUnary;
 
 template <std::ptrdiff_t N, typename Derived, typename Function>
 requires requires() {
-  requires std::invocable<Function, typename Derived::Scalar,
+  requires std::invocable<const Function&, typename Derived::Scalar,
                           typename Derived::Scalar>;
   requires std::convertible_to<
-      std::invoke_result_t<Function, typename Derived::Scalar,
+      std::invoke_result_t<const Function&, typename Derived::Scalar,
                            typename Derived::Scalar>,
       typename Derived::Scalar>;
 }
@@ -249,9 +249,9 @@ class CanonicalComponentFieldImag
 // Class for unary transformation.
 template <std::ptrdiff_t _N, typename Derived, typename Function>
 requires requires() {
-  requires std::invocable<Function, typename Derived::Scalar>;
+  requires std::invocable<const Function&, typename Derived::Scalar>;
   requires std::convertible_to<
-      std::invoke_result_t<Function, typename Derived::Scalar>,
+      std::invoke_result_t<const Function&, typename Derived::Scalar>,
       typename Derived::Scalar>;
 }
 class CanonicalComponentFieldUnary
@@ -303,10 +303,10 @@ class CanonicalComponentFieldUnary
 // Class for unary transformation with a scalar parameter.
 template <std::ptrdiff_t _N, typename Derived, typename Function>
 requires requires() {
-  requires std::invocable<Function, typename Derived::Scalar,
+  requires std::invocable<const Function&, typename Derived::Scalar,
                           typename Derived::Scalar>;
   requires std::convertible_to<
-      std::invoke_result_t<Function, typename Derived::Scalar,
+      std::invoke_result_t<const Function&, typename Derived::Scalar,
                            typename Derived::Scalar>,
       typename Derived::Scalar>;
 }

--- a/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldUnary.h
+++ b/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldUnary.h
@@ -4,6 +4,7 @@
 #include <complex>
 #include <concepts>
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -279,9 +280,11 @@ class CanonicalComponentFieldUnary
 
   // Constructors.
   CanonicalComponentFieldUnary() = delete;
+  template <typename Callable>
+  requires std::constructible_from<Function, Callable&&>
   CanonicalComponentFieldUnary(
-      const CanonicalComponentFieldBase<_N, Derived>& u, Function&& f)
-      : _u{u}, _f{std::forward<Function>(f)} {}
+      const CanonicalComponentFieldBase<_N, Derived>& u, Callable&& f)
+      : _u{u}, _f{std::forward<Callable>(f)} {}
 
   CanonicalComponentFieldUnary(const CanonicalComponentFieldUnary&) = default;
   CanonicalComponentFieldUnary(CanonicalComponentFieldUnary&&) = default;
@@ -333,9 +336,11 @@ class CanonicalComponentFieldUnaryWithScalar
 
   // Constructors.
   CanonicalComponentFieldUnaryWithScalar() = delete;
+  template <typename Callable>
+  requires std::constructible_from<Function, Callable&&>
   CanonicalComponentFieldUnaryWithScalar(
-      const CanonicalComponentFieldBase<_N, Derived>& u, Function&& f, Scalar s)
-      : _u{u}, _f{std::forward<Function>(f)}, _s{s} {}
+      const CanonicalComponentFieldBase<_N, Derived>& u, Callable&& f, Scalar s)
+      : _u{u}, _f{std::forward<Callable>(f)}, _s{s} {}
 
   CanonicalComponentFieldUnaryWithScalar(
       const CanonicalComponentFieldUnaryWithScalar&) = default;
@@ -353,6 +358,18 @@ class CanonicalComponentFieldUnaryWithScalar
   Function _f;
   Scalar _s;
 };
+
+template <std::ptrdiff_t N, typename Derived, typename Function>
+CanonicalComponentFieldUnary(const CanonicalComponentFieldBase<N, Derived>&,
+                             Function&&)
+    -> CanonicalComponentFieldUnary<N, Derived, std::decay_t<Function>>;
+
+template <std::ptrdiff_t N, typename Derived, typename Function>
+CanonicalComponentFieldUnaryWithScalar(
+    const CanonicalComponentFieldBase<N, Derived>&, Function&&,
+    typename Derived::Scalar)
+    -> CanonicalComponentFieldUnaryWithScalar<N, Derived,
+                                              std::decay_t<Function>>;
 
 }  // namespace GSHTrans
 

--- a/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldUnary.h
+++ b/GSHTrans/src/CanonicalComponentField/CanonicalComponentFieldUnary.h
@@ -4,6 +4,7 @@
 #include <complex>
 #include <concepts>
 #include <cstddef>
+#include <utility>
 #include <vector>
 
 #include "../Concepts.h"
@@ -280,7 +281,7 @@ class CanonicalComponentFieldUnary
   CanonicalComponentFieldUnary() = delete;
   CanonicalComponentFieldUnary(
       const CanonicalComponentFieldBase<_N, Derived>& u, Function&& f)
-      : _u{u}, _f{f} {}
+      : _u{u}, _f{std::forward<Function>(f)} {}
 
   CanonicalComponentFieldUnary(const CanonicalComponentFieldUnary&) = default;
   CanonicalComponentFieldUnary(CanonicalComponentFieldUnary&&) = default;
@@ -293,7 +294,7 @@ class CanonicalComponentFieldUnary
 
  private:
   const CanonicalComponentFieldBase<_N, Derived>& _u;
-  Function& _f;
+  Function _f;
 };
 
 // Class for unary transformation with a scalar parameter.
@@ -334,7 +335,7 @@ class CanonicalComponentFieldUnaryWithScalar
   CanonicalComponentFieldUnaryWithScalar() = delete;
   CanonicalComponentFieldUnaryWithScalar(
       const CanonicalComponentFieldBase<_N, Derived>& u, Function&& f, Scalar s)
-      : _u{u}, _f{f}, _s{s} {}
+      : _u{u}, _f{std::forward<Function>(f)}, _s{s} {}
 
   CanonicalComponentFieldUnaryWithScalar(
       const CanonicalComponentFieldUnaryWithScalar&) = default;
@@ -349,7 +350,7 @@ class CanonicalComponentFieldUnaryWithScalar
 
  private:
   const CanonicalComponentFieldBase<_N, Derived>& _u;
-  const Function& _f;
+  Function _f;
   Scalar _s;
 };
 

--- a/GSHTrans/src/GaussLegendreGrid.h
+++ b/GSHTrans/src/GaussLegendreGrid.h
@@ -92,14 +92,17 @@ class GaussLegendreGrid
   }
 
   auto Longitudes() const {
-    auto dPhi = 2 * std::numbers::pi_v<Real> / static_cast<Real>(2 * _lMax);
-    return std::ranges::views::iota(0, 2 * _lMax) |
+    const auto nPhi = std::max(Int{1}, 2 * _lMax);
+    const auto dPhi =
+        2 * std::numbers::pi_v<Real> / static_cast<Real>(nPhi);
+    return std::ranges::views::iota(Int{0}, nPhi) |
            std::ranges::views::transform([dPhi](auto i) { return i * dPhi; });
   }
   auto LongitudeWeights() const {
-    auto dPhi = 2 * std::numbers::pi_v<Real> / static_cast<Real>(2 * _lMax);
-    ;
-    return std::ranges::views::repeat(dPhi, 2 * _lMax);
+    const auto nPhi = std::max(Int{1}, 2 * _lMax);
+    const auto dPhi =
+        2 * std::numbers::pi_v<Real> / static_cast<Real>(nPhi);
+    return std::ranges::views::repeat(dPhi, nPhi);
   }
 
   //-----------------------------------------------------//
@@ -135,7 +138,8 @@ class GaussLegendreGrid
 
     // Deal with lMax = 0
     if (lMax == 0) {
-      out[0] = in[0] * std::numbers::inv_sqrtpi_v<Real> / static_cast<Real>(2);
+      out[0] =
+          in[0] * static_cast<Real>(2) / std::numbers::inv_sqrtpi_v<Real>;
       return;
     }
 
@@ -250,11 +254,11 @@ class GaussLegendreGrid
     // Deal with lMax = 0
     if (lMax == 0) {
       if constexpr (RealFloatingPoint<Scalar>) {
-        out[0] = std::real(in[0]) * static_cast<Real>(2) /
-                 std::numbers::inv_sqrtpi_v<Real>;
+        out[0] = std::real(in[0]) * std::numbers::inv_sqrtpi_v<Real> /
+                 static_cast<Real>(2);
       } else {
-        out[0] =
-            in[0] * static_cast<Real>(2) / std::numbers::inv_sqrtpi_v<Real>;
+        out[0] = in[0] * std::numbers::inv_sqrtpi_v<Real> /
+                 static_cast<Real>(2);
       }
       return;
     }

--- a/GSHTrans/src/GaussLegendreGrid.h
+++ b/GSHTrans/src/GaussLegendreGrid.h
@@ -12,6 +12,7 @@
 #include <numbers>
 #include <numeric>
 #include <ranges>
+#include <stdexcept>
 #include <vector>
 
 #include "Concepts.h"
@@ -125,8 +126,7 @@ class GaussLegendreGrid
     // Get scalar type for field.
     using Scalar = std::ranges::range_value_t<InRange>;
 
-    // Check upper index is possible.
-    assert(std::ranges::contains(this->UpperIndices(), n));
+    ValidateTransformRequest(lMax, n);
 
     // Check dimensions of ranges.
     assert(in.size() == this->FieldSize());
@@ -240,8 +240,7 @@ class GaussLegendreGrid
     // Get scalar type for field.
     using Scalar = std::ranges::range_value_t<OutRange>;
 
-    // Check upper index is possible.
-    assert(std::ranges::contains(this->UpperIndices(), n));
+    ValidateTransformRequest(lMax, n);
 
     // Check dimensions of ranges.
     if constexpr (RealFloatingPoint<Scalar>) {
@@ -325,6 +324,18 @@ class GaussLegendreGrid
   }
 
  private:
+  void ValidateTransformRequest(Int lMax, Int n) const {
+    if (lMax < 0 || lMax > MaxDegree()) {
+      throw std::invalid_argument(
+          "Transform degree must be between zero and the grid maximum degree");
+    }
+    if (std::abs(n) > lMax ||
+        !std::ranges::contains(this->UpperIndices(), n)) {
+      throw std::invalid_argument(
+          "Transform upper index is not supported at the requested degree");
+    }
+  }
+
   Int _lMax;
   Int _nMax;
   FFTWpp::Flag _flag;

--- a/GSHTrans/src/GaussLegendreGrid.h
+++ b/GSHTrans/src/GaussLegendreGrid.h
@@ -136,8 +136,8 @@ class GaussLegendreGrid
       assert(out.size() == GSHIndices<All>(lMax, lMax, n).Size());
     }
 
-    // Deal with lMax = 0
-    if (lMax == 0) {
+    // A one-point grid needs no FFT.
+    if (_lMax == 0) {
       out[0] =
           in[0] * static_cast<Real>(2) / std::numbers::inv_sqrtpi_v<Real>;
       return;
@@ -251,8 +251,8 @@ class GaussLegendreGrid
     }
     assert(out.size() == this->FieldSize());
 
-    // Deal with lMax = 0
-    if (lMax == 0) {
+    // A one-point grid needs no FFT.
+    if (_lMax == 0) {
       if constexpr (RealFloatingPoint<Scalar>) {
         out[0] = std::real(in[0]) * std::numbers::inv_sqrtpi_v<Real> /
                  static_cast<Real>(2);

--- a/GSHTrans/src/Wigner.h
+++ b/GSHTrans/src/Wigner.h
@@ -254,14 +254,14 @@ class Wigner {
   auto operator[](Int iTheta) const
   requires std::same_as<NRange, Single> && (!std::same_as<AngleRange, Single>)
   {
-    return operator[](0, iTheta);
+    return operator[](_nMax, iTheta);
   }
 
   // Return subview to data for l when NRange = Single and AngleRange = Single
   auto operator[](Int l) const
   requires std::same_as<NRange, Single> && std::same_as<AngleRange, Single>
   {
-    return operator[](0, 0)[l];
+    return operator[](_nMax, 0)[l];
   }
 
  private:

--- a/implementation_status.md
+++ b/implementation_status.md
@@ -151,4 +151,61 @@ Branch: `fix/correctness-and-safety`
   the ptraced execution environment.
 - `git diff --check` passed.
 
-All approved phases are complete.
+## Second pull request review corrections
+
+1. [x] Reject differently sized field compound operations in all build modes.
+2. [x] Reject differently sized expansion compound operations in all build
+   modes.
+3. [x] Validate requested transform degrees against the grid.
+
+### Issue 1 verification
+
+- All seven canonical-field tests passed in a fresh Debug build.
+- All seven canonical-field tests passed in a fresh Release build with
+  AddressSanitizer and UBSan in
+  `/tmp/gshtrans-review2-field-release-asan-uudG2Z`.
+- Leak detection was disabled because it is unsupported in the ptraced
+  execution environment.
+
+### Issue 2 implementation
+
+- Expansion assignment, addition-assignment, and subtraction-assignment now
+  share one runtime size check.
+- Added a regression covering both operand orderings for mismatched `+=` and
+  `-=`.
+
+### Issue 2 verification
+
+- All six canonical-expansion tests passed in the fresh Debug build.
+- All six canonical-expansion tests passed in the assertion-disabled Release
+  build with AddressSanitizer and UBSan.
+- Leak detection was disabled because it is unsupported in the ptraced
+  execution environment.
+
+### Issue 3 implementation
+
+- Forward and inverse transforms now reject negative degrees, degrees above the
+  grid maximum, and upper indices unsupported by either the requested degree or
+  the grid.
+- Added regressions for the one-point fast path, a larger grid, and upper
+  indices outside the requested degree or the grid's supported range.
+
+### Issue 3 verification
+
+- All nine Gauss-Legendre grid tests passed in the fresh Debug build.
+- All nine Gauss-Legendre grid tests passed in the assertion-disabled Release
+  build with AddressSanitizer and UBSan.
+- Leak detection was disabled because it is unsupported in the ptraced
+  execution environment.
+
+### Integrated verification
+
+- All examples and tests built in the fresh Debug and assertion-disabled
+  Release sanitizer builds.
+- All 32 tests passed across three repeated Debug runs.
+- All 32 tests passed in Release with AddressSanitizer and UBSan.
+- Leak detection was disabled because it is unsupported in the ptraced
+  execution environment.
+- `git diff --check` passed.
+
+All approved second-review corrections are complete.

--- a/implementation_status.md
+++ b/implementation_status.md
@@ -133,4 +133,22 @@ Branch: `fix/correctness-and-safety`
   disabled because it is unsupported in the ptraced execution environment.
 - The new lvalue-callable regression passed in both builds.
 
+## Independent pull request review corrections
+
+- [x] Reject differently sized field and expansion assignments in all build
+  modes before copying into destination storage.
+- [x] Correct degree-zero truncation on grids whose maximum degree is nonzero.
+- [x] Align callable constraints with const expression evaluation.
+
+### Verification
+
+- All 29 tests passed across three repeated Debug runs.
+- All 29 tests passed with AddressSanitizer and UBSan in the Debug build.
+- A fresh Release build with AddressSanitizer and UBSan completed in
+  `/tmp/gshtrans-review-release-asan-bb9is6`; all 29 tests passed with
+  assertions disabled.
+- Leak detection was disabled in sanitizer builds because it is unsupported in
+  the ptraced execution environment.
+- `git diff --check` passed.
+
 All approved phases are complete.

--- a/implementation_status.md
+++ b/implementation_status.md
@@ -108,12 +108,29 @@ Branch: `fix/correctness-and-safety`
 - Fresh Debug configure and build completed in
   `/tmp/gshtrans-phase5-debug-Z6EAn1`, reusing only previously downloaded
   dependency source trees.
-- All 25 tests passed, including five repeated runs of every test.
-- All 17 focused sanitizer probes passed in
+- All 26 tests passed, including five repeated runs of every test.
+- All 26 tests passed with AddressSanitizer and UBSan in
   `/tmp/gshtrans-phase1-asan-KpyRbq`; leak detection was disabled because it is
   unsupported in the ptraced execution environment.
 - `git diff --check` passed.
 - Only the approved source headers, focused tests, test registration, and this
   status file changed.
+
+## Pull request review follow-up
+
+- [x] Add the direct `<type_traits>` dependency used by callable decay.
+- [x] Decay lvalue callable types during class template argument deduction and
+  forward them into expression-owned state.
+- [x] Add a regression proving unary and scalar expressions copy lvalue
+  callables rather than retaining references.
+- [x] Remove assumptions about moved-from values from field and expansion
+  assignment tests.
+
+### Verification
+
+- All 26 tests passed, including five repeated Debug runs of every test.
+- All 26 tests passed with AddressSanitizer and UBSan; leak detection was
+  disabled because it is unsupported in the ptraced execution environment.
+- The new lvalue-callable regression passed in both builds.
 
 All approved phases are complete.

--- a/implementation_status.md
+++ b/implementation_status.md
@@ -1,0 +1,119 @@
+# Implementation Status
+
+Branch: `fix/correctness-and-safety`
+
+## Phase 1: Core numerical safety
+
+- [x] Use the configured upper index in `Wigner` single-index convenience
+  accessors.
+- [x] Give degree-zero grids one longitude with the correct quadrature weight.
+- [x] Correct degree-zero forward and inverse normalization.
+- [x] Add focused Wigner and degree-zero regression tests.
+- [x] Cover the valid upper-index boundaries `n = ±lMax`.
+- [x] Build and run the Phase 1 test suite.
+
+### Verification
+
+- Clean Debug build completed in `/tmp/gshtrans-phase1-mwIqx2`.
+- All 14 tests passed, including five repeated runs of every test.
+- The six focused regressions passed with AddressSanitizer and UBSan in
+  `/tmp/gshtrans-phase1-asan-KpyRbq`; leak detection was disabled because it is
+  unsupported in the ptraced execution environment.
+- `git diff --check` passed.
+
+## Phase 2: Canonical field correctness
+
+- [x] Use indexed access for every compound field operation.
+- [x] Materialize lazy expressions through the field's grid-only constructor.
+- [x] Own unary and scalar callable state by value and initialize it with
+  forwarding.
+- [x] Delete the unusable field default constructor.
+- [x] Make copy and move assignment copy values without rebinding the
+  destination grid.
+- [x] Test real and complex arithmetic, unary and scalar expressions,
+  materialization, callable ownership, and assignment.
+
+### Verification
+
+- The Debug build completed in `/tmp/gshtrans-phase1-mwIqx2`, including all
+  examples and test executables.
+- All 18 tests passed, including five repeated runs of every test.
+- All 18 tests passed with AddressSanitizer and UBSan in
+  `/tmp/gshtrans-phase1-asan-KpyRbq`; leak detection was disabled because it is
+  unsupported in the ptraced execution environment.
+- The four focused canonical-field regressions passed in both builds.
+- `git diff --check` passed.
+
+## Phase 3: Canonical expansion repair
+
+- [x] Replace public `GSHIndices` inheritance with a composed index member.
+- [x] Use complex coefficient storage and `Scalar` for real and complex
+  expansions.
+- [x] Expose only nonnegative orders for `RealValued` and every order for
+  `ComplexValued`.
+- [x] Repair degree/order iteration, coefficient indexing, and size queries.
+- [x] Provide mutable and const coefficient data views.
+- [x] Repair copy/move assignment, addition/subtraction assignment, and scalar
+  multiplication/division while preserving the destination grid.
+- [x] Restore the canonical component and scalar expansion aliases.
+- [x] Remove obsolete commented implementations from the two repaired
+  expansion headers.
+- [x] Test real and complex traits, indexing, iteration, storage, assignment,
+  and compound arithmetic.
+
+### Verification
+
+- The Debug build completed in `/tmp/gshtrans-phase1-mwIqx2`, including all
+  examples and test executables.
+- All 22 tests passed, including five repeated runs of every test.
+- All 22 tests passed with AddressSanitizer and UBSan in
+  `/tmp/gshtrans-phase1-asan-KpyRbq`; leak detection was disabled because it is
+  unsupported in the ptraced execution environment.
+- The four focused canonical-expansion regressions passed in both builds.
+- `git diff --check` passed.
+
+## Phase 4: Real-field symmetry validation
+
+- [x] Document `RealValued` as a reduced `m >= 0` representation of real grid
+  samples whose stored coefficients remain complex.
+- [x] Verify reduced coefficients at `n = ±2` agree with the nonduplicated
+  nonnegative-order portion of full complex transforms of the same samples.
+- [x] Verify the `m = 0` and Nyquist coefficients satisfy the required real
+  Fourier constraints.
+- [x] Treat the Nyquist corner explicitly: the full complex transform stores
+  the shared FFT bin at negative order and zeros the duplicate positive-order
+  corner.
+- [x] Verify
+  `a(l,-m,-n) = (-1)^(m-n) conjugate(a(l,m,n))` between full transforms at
+  `+n` and `-n`, with the duplicated Nyquist corner checked separately.
+- [x] Verify reduced inverse synthesis equals synthesis from the explicit
+  positive-`n` and negative-`n` Hermitian pair.
+
+### Verification
+
+- All three focused symmetry regressions passed in Debug and with
+  AddressSanitizer/UBSan.
+
+## Phase 5: Integrated verification
+
+- [x] Configure a fresh Debug build in `/tmp`.
+- [x] Build all examples and test executables.
+- [x] Run the complete test suite repeatedly.
+- [x] Run focused AddressSanitizer/UBSan probes for Wigner access, degree zero,
+  field expressions, expansions, and real-field symmetry.
+- [x] Check whitespace and confirm the changed-file scope.
+
+### Verification
+
+- Fresh Debug configure and build completed in
+  `/tmp/gshtrans-phase5-debug-Z6EAn1`, reusing only previously downloaded
+  dependency source trees.
+- All 25 tests passed, including five repeated runs of every test.
+- All 17 focused sanitizer probes passed in
+  `/tmp/gshtrans-phase1-asan-KpyRbq`; leak detection was disabled because it is
+  unsupported in the ptraced execution environment.
+- `git diff --check` passed.
+- Only the approved source headers, focused tests, test registration, and this
+  status file changed.
+
+All approved phases are complete.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,22 @@ target_link_libraries(TestWigner PRIVATE GSHTrans gtest_main)
 add_executable(TestGaussLegendreGrid
                TestGaussLegendreGrid.cpp)
 target_link_libraries(TestGaussLegendreGrid PRIVATE GSHTrans gtest_main)
-	     
+
+add_executable(TestCanonicalComponentField
+               TestCanonicalComponentField.cpp)
+target_link_libraries(TestCanonicalComponentField PRIVATE GSHTrans gtest_main)
+
+add_executable(TestCanonicalComponentExpansion
+               TestCanonicalComponentExpansion.cpp)
+target_link_libraries(TestCanonicalComponentExpansion PRIVATE GSHTrans gtest_main)
+
+add_executable(TestRealFieldSymmetry
+               TestRealFieldSymmetry.cpp)
+target_link_libraries(TestRealFieldSymmetry PRIVATE GSHTrans gtest_main)
+
 include(GoogleTest)
 gtest_discover_tests(TestWigner)
 gtest_discover_tests(TestGaussLegendreGrid)
+gtest_discover_tests(TestCanonicalComponentField)
+gtest_discover_tests(TestCanonicalComponentExpansion)
+gtest_discover_tests(TestRealFieldSymmetry)

--- a/tests/TestCanonicalComponentExpansion.cpp
+++ b/tests/TestCanonicalComponentExpansion.cpp
@@ -82,10 +82,12 @@ void CheckAssignmentAndArithmetic() {
   });
 
   Fill(source, Complex{8.0, 2.0});
+  const auto expectedAfterMove = Expansion(source);
   destination = std::move(source);
   EXPECT_EQ(&destination.Grid(), &destinationGrid);
-  ExpectValues(destination,
-               [&](auto l, auto m) { return source[l, m]; });
+  ExpectValues(destination, [&](auto l, auto m) {
+    return expectedAfterMove[l, m];
+  });
 }
 
 }  // namespace

--- a/tests/TestCanonicalComponentExpansion.cpp
+++ b/tests/TestCanonicalComponentExpansion.cpp
@@ -5,6 +5,7 @@
 #include <complex>
 #include <cstddef>
 #include <ranges>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 
@@ -184,4 +185,19 @@ TEST(CanonicalComponentExpansion, RealAssignmentAndArithmetic) {
 
 TEST(CanonicalComponentExpansion, ComplexAssignmentAndArithmetic) {
   CheckAssignmentAndArithmetic<ComplexExpansion>();
+}
+
+TEST(CanonicalComponentExpansion, AssignmentRejectsMismatchedGridSizes) {
+  auto smallGrid = Grid(1, 0, FFTWpp::Estimate);
+  auto largeGrid = Grid(2, 0, FFTWpp::Estimate);
+  auto small = RealExpansion(smallGrid);
+  auto large = RealExpansion(largeGrid);
+
+  EXPECT_THROW(small = large, std::invalid_argument);
+  EXPECT_THROW(small = std::move(large), std::invalid_argument);
+
+  using Base = CanonicalComponentExpansionBase<1, RealExpansion>;
+  auto& smallBase = static_cast<Base&>(small);
+  EXPECT_THROW(smallBase.template operator=<RealExpansion>(large),
+               std::invalid_argument);
 }

--- a/tests/TestCanonicalComponentExpansion.cpp
+++ b/tests/TestCanonicalComponentExpansion.cpp
@@ -1,0 +1,185 @@
+#include <gtest/gtest.h>
+
+#include <GSHTrans/All>
+
+#include <complex>
+#include <cstddef>
+#include <ranges>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+using namespace GSHTrans;
+
+using Real = double;
+using Complex = std::complex<Real>;
+using Grid = GaussLegendreGrid<Real, All, All>;
+using RealExpansion = RealCanonicalComponentExpansion<1, Grid>;
+using ComplexExpansion = ComplexCanonicalComponentExpansion<1, Grid>;
+
+void ExpectNear(Complex actual, Complex expected) {
+  EXPECT_NEAR(actual.real(), expected.real(), 1.0e-12);
+  EXPECT_NEAR(actual.imag(), expected.imag(), 1.0e-12);
+}
+
+template <typename Expansion>
+void Fill(Expansion& expansion, Complex offset) {
+  auto i = std::ptrdiff_t{0};
+  for (auto [l, m] : expansion.Indices()) {
+    expansion[l, m] =
+        offset + Complex{static_cast<Real>(i), -static_cast<Real>(2 * i)};
+    ++i;
+  }
+}
+
+template <typename Expansion, typename Function>
+void ExpectValues(const Expansion& expansion, Function expected) {
+  for (auto [l, m] : expansion.Indices()) {
+    ExpectNear(expansion[l, m], expected(l, m));
+  }
+}
+
+template <typename Expansion>
+void CheckAssignmentAndArithmetic() {
+  auto destinationGrid = Grid(3, 1, FFTWpp::Estimate);
+  auto sourceGrid = Grid(3, 1, FFTWpp::Estimate);
+  auto destination = Expansion(destinationGrid);
+  auto source = Expansion(sourceGrid);
+  auto other = Expansion(sourceGrid);
+  Fill(source, Complex{2.0, -1.0});
+  Fill(other, Complex{-0.5, 3.0});
+
+  destination = source;
+  EXPECT_EQ(&destination.Grid(), &destinationGrid);
+  ExpectValues(destination,
+               [&](auto l, auto m) { return source[l, m]; });
+
+  destination += other;
+  ExpectValues(destination, [&](auto l, auto m) {
+    return source[l, m] + other[l, m];
+  });
+
+  destination = source;
+  destination -= other;
+  ExpectValues(destination, [&](auto l, auto m) {
+    return source[l, m] - other[l, m];
+  });
+
+  const auto scalar = Complex{1.5, -0.25};
+  destination = source;
+  destination *= scalar;
+  ExpectValues(destination, [&](auto l, auto m) {
+    return source[l, m] * scalar;
+  });
+  destination /= scalar;
+  ExpectValues(destination,
+               [&](auto l, auto m) { return source[l, m]; });
+
+  destination += Expansion(other);
+  ExpectValues(destination, [&](auto l, auto m) {
+    return source[l, m] + other[l, m];
+  });
+
+  Fill(source, Complex{8.0, 2.0});
+  destination = std::move(source);
+  EXPECT_EQ(&destination.Grid(), &destinationGrid);
+  ExpectValues(destination,
+               [&](auto l, auto m) { return source[l, m]; });
+}
+
+}  // namespace
+
+TEST(CanonicalComponentExpansion, TraitsAndOrderRanges) {
+  static_assert(std::same_as<RealExpansion::Scalar, Complex>);
+  static_assert(std::same_as<ComplexExpansion::Scalar, Complex>);
+  static_assert(std::same_as<RealExpansion::MRange, NonNegative>);
+  static_assert(std::same_as<ComplexExpansion::MRange, All>);
+  static_assert(
+      !std::is_base_of_v<GSHIndices<NonNegative>, RealExpansion>);
+  static_assert(!std::is_base_of_v<GSHIndices<All>, ComplexExpansion>);
+  static_assert(!std::is_default_constructible_v<RealExpansion>);
+  static_assert(!std::is_default_constructible_v<ComplexExpansion>);
+  static_assert(std::same_as<RealScalarExpansion<Grid>,
+                             ScalarExpansion<Grid, RealValued>>);
+  static_assert(std::same_as<ComplexScalarExpansion<Grid>,
+                             ScalarExpansion<Grid, ComplexValued>>);
+
+  auto grid = Grid(3, 1, FFTWpp::Estimate);
+  auto realExpansion = RealExpansion(grid);
+  auto complexExpansion = ComplexExpansion(grid);
+
+  EXPECT_EQ(realExpansion.MinDegree(), 1);
+  EXPECT_EQ(realExpansion.MaxDegree(), 3);
+  EXPECT_EQ(realExpansion.MaxOrder(), 3);
+  EXPECT_EQ(realExpansion.Size(), GSHIndices<NonNegative>(3, 3, 1).Size());
+  EXPECT_EQ(complexExpansion.Size(), GSHIndices<All>(3, 3, 1).Size());
+
+  auto realIndex = std::ptrdiff_t{0};
+  for (auto [l, m] : realExpansion.Indices()) {
+    EXPECT_GE(m, 0);
+    EXPECT_LE(m, l);
+    EXPECT_EQ(realExpansion.Index(l, m), realIndex);
+    ++realIndex;
+  }
+  EXPECT_EQ(realIndex, realExpansion.Size());
+
+  auto complexIndex = std::ptrdiff_t{0};
+  auto sawNegativeOrder = false;
+  for (auto [l, m] : complexExpansion.Indices()) {
+    sawNegativeOrder = sawNegativeOrder || m < 0;
+    EXPECT_GE(m, -l);
+    EXPECT_LE(m, l);
+    EXPECT_EQ(complexExpansion.Index(l, m), complexIndex);
+    ++complexIndex;
+  }
+  EXPECT_TRUE(sawNegativeOrder);
+  EXPECT_EQ(complexIndex, complexExpansion.Size());
+
+  auto orders = realExpansion.Orders();
+  auto order = orders.begin();
+  for (auto [l, m] : realExpansion.Indices()) {
+    static_cast<void>(l);
+    ASSERT_NE(order, orders.end());
+    EXPECT_EQ(*order, m);
+    ++order;
+  }
+}
+
+TEST(CanonicalComponentExpansion, ComplexStorageAndDataAccess) {
+  using MutableData = decltype(std::declval<RealExpansion&>().Data());
+  using ConstData = decltype(std::declval<const RealExpansion&>().Data());
+  static_assert(std::ranges::output_range<MutableData, Complex>);
+  static_assert(!std::ranges::output_range<ConstData, Complex>);
+
+  auto grid = Grid(3, 1, FFTWpp::Estimate);
+  auto realExpansion = RealExpansion(grid);
+  auto complexExpansion = ComplexExpansion(grid);
+  Fill(realExpansion, Complex{1.0, 4.0});
+  Fill(complexExpansion, Complex{-2.0, 5.0});
+
+  auto sawImaginaryValue = false;
+  for (auto [l, m] : realExpansion.Indices()) {
+    const auto i = realExpansion.Index(l, m);
+    ExpectNear(realExpansion.Data()[i], realExpansion[l, m]);
+    sawImaginaryValue =
+        sawImaginaryValue || realExpansion[l, m].imag() != 0.0;
+  }
+  EXPECT_TRUE(sawImaginaryValue);
+  for (auto [l, m] : complexExpansion.Indices()) {
+    const auto i = complexExpansion.Index(l, m);
+    ExpectNear(complexExpansion.Data()[i], complexExpansion[l, m]);
+  }
+
+  const auto& constExpansion = realExpansion;
+  EXPECT_EQ(constExpansion.Data().size(), realExpansion.Size());
+  ExpectNear(constExpansion.Data()[0], realExpansion.Data()[0]);
+}
+
+TEST(CanonicalComponentExpansion, RealAssignmentAndArithmetic) {
+  CheckAssignmentAndArithmetic<RealExpansion>();
+}
+
+TEST(CanonicalComponentExpansion, ComplexAssignmentAndArithmetic) {
+  CheckAssignmentAndArithmetic<ComplexExpansion>();
+}

--- a/tests/TestCanonicalComponentExpansion.cpp
+++ b/tests/TestCanonicalComponentExpansion.cpp
@@ -201,3 +201,16 @@ TEST(CanonicalComponentExpansion, AssignmentRejectsMismatchedGridSizes) {
   EXPECT_THROW(smallBase.template operator=<RealExpansion>(large),
                std::invalid_argument);
 }
+
+TEST(CanonicalComponentExpansion,
+     CompoundAssignmentsRejectMismatchedGridSizes) {
+  auto smallGrid = Grid(1, 0, FFTWpp::Estimate);
+  auto largeGrid = Grid(2, 0, FFTWpp::Estimate);
+  auto small = RealExpansion(smallGrid);
+  auto large = RealExpansion(largeGrid);
+
+  EXPECT_THROW(small += large, std::invalid_argument);
+  EXPECT_THROW(small -= large, std::invalid_argument);
+  EXPECT_THROW(large += small, std::invalid_argument);
+  EXPECT_THROW(large -= small, std::invalid_argument);
+}

--- a/tests/TestCanonicalComponentField.cpp
+++ b/tests/TestCanonicalComponentField.cpp
@@ -1,0 +1,308 @@
+#include <gtest/gtest.h>
+
+#include <GSHTrans/All>
+
+#include <complex>
+#include <memory>
+#include <type_traits>
+
+namespace {
+
+using namespace GSHTrans;
+
+using Real = double;
+using Complex = std::complex<Real>;
+using Grid = GaussLegendreGrid<Real, All, All>;
+using RealField = RealCanonicalComponentField<0, Grid>;
+using ComplexField = ComplexCanonicalComponentField<0, Grid>;
+
+void ExpectNear(Real actual, Real expected) {
+  EXPECT_NEAR(actual, expected, 1.0e-12);
+}
+
+void ExpectNear(Complex actual, Complex expected) {
+  EXPECT_NEAR(actual.real(), expected.real(), 1.0e-12);
+  EXPECT_NEAR(actual.imag(), expected.imag(), 1.0e-12);
+}
+
+template <typename Field, typename Function>
+void Fill(Field& field, Function value) {
+  for (auto [iTheta, iPhi] : field.PointIndices()) {
+    field[iTheta, iPhi] = value(iTheta, iPhi);
+  }
+}
+
+template <typename Field, typename Function>
+void ExpectValues(const Field& field, Function expected) {
+  for (auto [iTheta, iPhi] : field.PointIndices()) {
+    ExpectNear(field[iTheta, iPhi], expected(iTheta, iPhi));
+  }
+}
+
+template <typename Field>
+void CheckCompoundArithmetic(Field& u, const Field& v,
+                             typename Field::Scalar scalar) {
+  Field result(u.Grid());
+
+  result = u;
+  result += v;
+  ExpectValues(result, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] + v[iTheta, iPhi];
+  });
+
+  result = u;
+  result -= v;
+  ExpectValues(result, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] - v[iTheta, iPhi];
+  });
+
+  result = u;
+  result *= v;
+  ExpectValues(result, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] * v[iTheta, iPhi];
+  });
+
+  result = u;
+  result /= v;
+  ExpectValues(result, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] / v[iTheta, iPhi];
+  });
+
+  result = u;
+  result += scalar;
+  ExpectValues(result, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] + scalar;
+  });
+
+  result = u;
+  result -= scalar;
+  ExpectValues(result, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] - scalar;
+  });
+
+  result = u;
+  result *= scalar;
+  ExpectValues(result, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] * scalar;
+  });
+
+  result = u;
+  result /= scalar;
+  ExpectValues(result, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] / scalar;
+  });
+}
+
+class MoveOnlyUnary {
+ public:
+  explicit MoveOnlyUnary(Real offset)
+      : _offset{std::make_unique<Real>(offset)} {}
+
+  MoveOnlyUnary(const MoveOnlyUnary&) = delete;
+  MoveOnlyUnary(MoveOnlyUnary&&) = default;
+
+  Real operator()(Real value) const { return value + *_offset; }
+
+ private:
+  std::unique_ptr<Real> _offset;
+};
+
+class MoveOnlyScalarCallable {
+ public:
+  explicit MoveOnlyScalarCallable(Real factor)
+      : _factor{std::make_unique<Real>(factor)} {}
+
+  MoveOnlyScalarCallable(const MoveOnlyScalarCallable&) = delete;
+  MoveOnlyScalarCallable(MoveOnlyScalarCallable&&) = default;
+
+  Real operator()(Real value, Real scalar) const {
+    return *_factor * value + scalar;
+  }
+
+ private:
+  std::unique_ptr<Real> _factor;
+};
+
+}  // namespace
+
+TEST(CanonicalComponentField, RealArithmeticAndMaterialization) {
+  auto grid = Grid(2, 0, FFTWpp::Estimate);
+  auto u = RealField(grid);
+  auto v = RealField(grid);
+  Fill(u, [](auto iTheta, auto iPhi) {
+    return 2.0 + static_cast<Real>(iTheta + 2 * iPhi);
+  });
+  Fill(v, [](auto iTheta, auto iPhi) {
+    return 5.0 + static_cast<Real>(2 * iTheta + iPhi);
+  });
+
+  auto sum = RealField(u + v);
+  auto difference = RealField(u - v);
+  auto product = RealField(u * v);
+  auto quotient = RealField(u / v);
+  auto negative = RealField(-u);
+  auto shifted = RealField(u + 3.0);
+  auto leftShifted = RealField(3.0 + u);
+  auto reduced = RealField(u - 1.0);
+  auto scaled = RealField(u * 2.5);
+  auto leftScaled = RealField(2.5 * u);
+  auto divided = RealField(u / 2.0);
+  auto nested = RealField((u + v) - v);
+
+  ExpectValues(sum, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] + v[iTheta, iPhi];
+  });
+  ExpectValues(difference, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] - v[iTheta, iPhi];
+  });
+  ExpectValues(product, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] * v[iTheta, iPhi];
+  });
+  ExpectValues(quotient, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] / v[iTheta, iPhi];
+  });
+  ExpectValues(negative,
+               [&](auto iTheta, auto iPhi) { return -u[iTheta, iPhi]; });
+  ExpectValues(shifted, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] + 3.0;
+  });
+  ExpectValues(leftShifted, [&](auto iTheta, auto iPhi) {
+    return 3.0 + u[iTheta, iPhi];
+  });
+  ExpectValues(reduced, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] - 1.0;
+  });
+  ExpectValues(scaled, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] * 2.5;
+  });
+  ExpectValues(leftScaled, [&](auto iTheta, auto iPhi) {
+    return 2.5 * u[iTheta, iPhi];
+  });
+  ExpectValues(divided, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] / 2.0;
+  });
+  ExpectValues(nested, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi];
+  });
+
+  CheckCompoundArithmetic(u, v, 2.0);
+}
+
+TEST(CanonicalComponentField, ComplexArithmeticAndUnaryExpressions) {
+  auto grid = Grid(2, 0, FFTWpp::Estimate);
+  auto u = ComplexField(grid);
+  auto v = ComplexField(grid);
+  Fill(u, [](auto iTheta, auto iPhi) {
+    return Complex{2.0 + static_cast<Real>(iTheta),
+                   1.0 + static_cast<Real>(iPhi)};
+  });
+  Fill(v, [](auto iTheta, auto iPhi) {
+    return Complex{4.0 + static_cast<Real>(iPhi),
+                   2.0 + static_cast<Real>(iTheta)};
+  });
+
+  auto sum = ComplexField(u + v);
+  auto difference = ComplexField(u - v);
+  auto product = ComplexField(u * v);
+  auto quotient = ComplexField(u / v);
+  auto conjugate = ComplexField(conj(u));
+  auto realPart = RealField(real(u));
+  auto imaginaryPart = RealField(imag(u));
+  const auto scalar = Complex{1.5, -0.5};
+  auto shifted = ComplexField(u - scalar);
+  auto scaled = ComplexField(u / scalar);
+  auto leftShifted = ComplexField(scalar + u);
+  auto leftScaled = ComplexField(scalar * u);
+
+  ExpectValues(sum, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] + v[iTheta, iPhi];
+  });
+  ExpectValues(difference, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] - v[iTheta, iPhi];
+  });
+  ExpectValues(product, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] * v[iTheta, iPhi];
+  });
+  ExpectValues(quotient, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] / v[iTheta, iPhi];
+  });
+  ExpectValues(conjugate, [&](auto iTheta, auto iPhi) {
+    return std::conj(u[iTheta, iPhi]);
+  });
+  ExpectValues(realPart, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi].real();
+  });
+  ExpectValues(imaginaryPart, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi].imag();
+  });
+  ExpectValues(shifted, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] - scalar;
+  });
+  ExpectValues(scaled, [&](auto iTheta, auto iPhi) {
+    return u[iTheta, iPhi] / scalar;
+  });
+  ExpectValues(leftShifted, [&](auto iTheta, auto iPhi) {
+    return scalar + u[iTheta, iPhi];
+  });
+  ExpectValues(leftScaled, [&](auto iTheta, auto iPhi) {
+    return scalar * u[iTheta, iPhi];
+  });
+
+  CheckCompoundArithmetic(u, v, scalar);
+}
+
+TEST(CanonicalComponentField, AssignmentPreservesDestinationGrid) {
+  static_assert(!std::is_default_constructible_v<RealField>);
+  static_assert(!std::is_default_constructible_v<ComplexField>);
+
+  auto destinationGrid = Grid(2, 0, FFTWpp::Estimate);
+  auto sourceGrid = Grid(2, 0, FFTWpp::Estimate);
+  auto destination = RealField(destinationGrid);
+  auto source = RealField(sourceGrid);
+  Fill(source, [](auto iTheta, auto iPhi) {
+    return 7.0 + static_cast<Real>(3 * iTheta + iPhi);
+  });
+
+  destination = source;
+  EXPECT_EQ(&destination.Grid(), &destinationGrid);
+  ExpectValues(destination, [&](auto iTheta, auto iPhi) {
+    return source[iTheta, iPhi];
+  });
+
+  Fill(source, [](auto iTheta, auto iPhi) {
+    return 11.0 + static_cast<Real>(iTheta + 4 * iPhi);
+  });
+  destination = std::move(source);
+  EXPECT_EQ(&destination.Grid(), &destinationGrid);
+  ExpectValues(destination, [&](auto iTheta, auto iPhi) {
+    return source[iTheta, iPhi];
+  });
+
+  destination = destination + destination;
+  EXPECT_EQ(&destination.Grid(), &destinationGrid);
+  ExpectValues(destination, [&](auto iTheta, auto iPhi) {
+    return 2.0 * source[iTheta, iPhi];
+  });
+}
+
+TEST(CanonicalComponentField, CallableExpressionsOwnForwardedState) {
+  auto grid = Grid(2, 0, FFTWpp::Estimate);
+  auto field = RealField(grid);
+  Fill(field, [](auto iTheta, auto iPhi) {
+    return 1.0 + static_cast<Real>(iTheta + iPhi);
+  });
+
+  auto unaryExpression =
+      CanonicalComponentFieldUnary(field, MoveOnlyUnary{4.0});
+  auto scalarExpression = CanonicalComponentFieldUnaryWithScalar(
+      field, MoveOnlyScalarCallable{3.0}, 2.0);
+
+  auto unaryResult = RealField(unaryExpression);
+  auto scalarResult = RealField(scalarExpression);
+  ExpectValues(unaryResult, [&](auto iTheta, auto iPhi) {
+    return field[iTheta, iPhi] + 4.0;
+  });
+  ExpectValues(scalarResult, [&](auto iTheta, auto iPhi) {
+    return 3.0 * field[iTheta, iPhi] + 2.0;
+  });
+}

--- a/tests/TestCanonicalComponentField.cpp
+++ b/tests/TestCanonicalComponentField.cpp
@@ -123,6 +123,30 @@ class MoveOnlyScalarCallable {
   std::unique_ptr<Real> _factor;
 };
 
+class StatefulUnary {
+ public:
+  explicit StatefulUnary(Real offset) : _offset{offset} {}
+
+  void SetOffset(Real offset) { _offset = offset; }
+  Real operator()(Real value) const { return value + _offset; }
+
+ private:
+  Real _offset;
+};
+
+class StatefulScalarCallable {
+ public:
+  explicit StatefulScalarCallable(Real factor) : _factor{factor} {}
+
+  void SetFactor(Real factor) { _factor = factor; }
+  Real operator()(Real value, Real scalar) const {
+    return _factor * value + scalar;
+  }
+
+ private:
+  Real _factor;
+};
+
 }  // namespace
 
 TEST(CanonicalComponentField, RealArithmeticAndMaterialization) {
@@ -272,16 +296,17 @@ TEST(CanonicalComponentField, AssignmentPreservesDestinationGrid) {
   Fill(source, [](auto iTheta, auto iPhi) {
     return 11.0 + static_cast<Real>(iTheta + 4 * iPhi);
   });
+  const auto expectedAfterMove = RealField(source);
   destination = std::move(source);
   EXPECT_EQ(&destination.Grid(), &destinationGrid);
   ExpectValues(destination, [&](auto iTheta, auto iPhi) {
-    return source[iTheta, iPhi];
+    return expectedAfterMove[iTheta, iPhi];
   });
 
   destination = destination + destination;
   EXPECT_EQ(&destination.Grid(), &destinationGrid);
   ExpectValues(destination, [&](auto iTheta, auto iPhi) {
-    return 2.0 * source[iTheta, iPhi];
+    return 2.0 * expectedAfterMove[iTheta, iPhi];
   });
 }
 
@@ -296,6 +321,33 @@ TEST(CanonicalComponentField, CallableExpressionsOwnForwardedState) {
       CanonicalComponentFieldUnary(field, MoveOnlyUnary{4.0});
   auto scalarExpression = CanonicalComponentFieldUnaryWithScalar(
       field, MoveOnlyScalarCallable{3.0}, 2.0);
+
+  auto unaryResult = RealField(unaryExpression);
+  auto scalarResult = RealField(scalarExpression);
+  ExpectValues(unaryResult, [&](auto iTheta, auto iPhi) {
+    return field[iTheta, iPhi] + 4.0;
+  });
+  ExpectValues(scalarResult, [&](auto iTheta, auto iPhi) {
+    return 3.0 * field[iTheta, iPhi] + 2.0;
+  });
+}
+
+TEST(CanonicalComponentField, LvalueCallablesAreCopiedIntoExpressions) {
+  auto grid = Grid(2, 0, FFTWpp::Estimate);
+  auto field = RealField(grid);
+  Fill(field, [](auto iTheta, auto iPhi) {
+    return 1.0 + static_cast<Real>(iTheta + iPhi);
+  });
+
+  auto unaryCallable = StatefulUnary{4.0};
+  auto scalarCallable = StatefulScalarCallable{3.0};
+  auto unaryExpression =
+      CanonicalComponentFieldUnary(field, unaryCallable);
+  auto scalarExpression = CanonicalComponentFieldUnaryWithScalar(
+      field, scalarCallable, 2.0);
+
+  unaryCallable.SetOffset(40.0);
+  scalarCallable.SetFactor(30.0);
 
   auto unaryResult = RealField(unaryExpression);
   auto scalarResult = RealField(scalarExpression);

--- a/tests/TestCanonicalComponentField.cpp
+++ b/tests/TestCanonicalComponentField.cpp
@@ -4,7 +4,9 @@
 
 #include <complex>
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
+#include <utility>
 
 namespace {
 
@@ -146,6 +148,34 @@ class StatefulScalarCallable {
  private:
   Real _factor;
 };
+
+class MutableUnary {
+ public:
+  Real operator()(Real value) { return value; }
+};
+
+class MutableScalarCallable {
+ public:
+  Real operator()(Real value, Real scalar) { return value + scalar; }
+};
+
+template <typename Callable>
+concept FormsUnaryExpression = requires(RealField& field, Callable&& callable) {
+  CanonicalComponentFieldUnary(field,
+                               std::forward<Callable>(callable));
+};
+
+template <typename Callable>
+concept FormsScalarExpression =
+    requires(RealField& field, Callable&& callable) {
+      CanonicalComponentFieldUnaryWithScalar(
+          field, std::forward<Callable>(callable), Real{});
+    };
+
+static_assert(FormsUnaryExpression<MoveOnlyUnary>);
+static_assert(FormsScalarExpression<MoveOnlyScalarCallable>);
+static_assert(!FormsUnaryExpression<MutableUnary>);
+static_assert(!FormsScalarExpression<MutableScalarCallable>);
 
 }  // namespace
 
@@ -308,6 +338,18 @@ TEST(CanonicalComponentField, AssignmentPreservesDestinationGrid) {
   ExpectValues(destination, [&](auto iTheta, auto iPhi) {
     return 2.0 * expectedAfterMove[iTheta, iPhi];
   });
+}
+
+TEST(CanonicalComponentField, AssignmentRejectsMismatchedGridSizes) {
+  auto smallGrid = Grid(1, 0, FFTWpp::Estimate);
+  auto largeGrid = Grid(2, 0, FFTWpp::Estimate);
+  auto small = RealField(smallGrid);
+  auto large = RealField(largeGrid);
+
+  EXPECT_THROW(small = large, std::invalid_argument);
+  EXPECT_THROW(small = std::move(large), std::invalid_argument);
+  EXPECT_THROW(small = large + 1.0, std::invalid_argument);
+  EXPECT_THROW(large = small + 1.0, std::invalid_argument);
 }
 
 TEST(CanonicalComponentField, CallableExpressionsOwnForwardedState) {

--- a/tests/TestCanonicalComponentField.cpp
+++ b/tests/TestCanonicalComponentField.cpp
@@ -352,6 +352,22 @@ TEST(CanonicalComponentField, AssignmentRejectsMismatchedGridSizes) {
   EXPECT_THROW(large = small + 1.0, std::invalid_argument);
 }
 
+TEST(CanonicalComponentField, CompoundAssignmentsRejectMismatchedGridSizes) {
+  auto smallGrid = Grid(1, 0, FFTWpp::Estimate);
+  auto largeGrid = Grid(2, 0, FFTWpp::Estimate);
+  auto small = RealField(smallGrid);
+  auto large = RealField(largeGrid);
+
+  EXPECT_THROW(small += large, std::invalid_argument);
+  EXPECT_THROW(small -= large, std::invalid_argument);
+  EXPECT_THROW(small *= large, std::invalid_argument);
+  EXPECT_THROW(small /= large, std::invalid_argument);
+  EXPECT_THROW(large += small, std::invalid_argument);
+  EXPECT_THROW(large -= small, std::invalid_argument);
+  EXPECT_THROW(large *= small, std::invalid_argument);
+  EXPECT_THROW(large /= small, std::invalid_argument);
+}
+
 TEST(CanonicalComponentField, CallableExpressionsOwnForwardedState) {
   auto grid = Grid(2, 0, FFTWpp::Estimate);
   auto field = RealField(grid);

--- a/tests/TestGaussLegendreGrid.cpp
+++ b/tests/TestGaussLegendreGrid.cpp
@@ -1,6 +1,74 @@
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <numbers>
+
 #include "CheckCoeff2Coeff.h"
+
+TEST(GaussLegendreGrid, DegreeZeroGeometryAndWeights) {
+  using Grid = GaussLegendreGrid<double, All, All>;
+  auto grid = Grid(0, 0, FFTWpp::Estimate);
+
+  ASSERT_EQ(grid.NumberOfCoLatitudes(), 1);
+  ASSERT_EQ(grid.NumberOfLongitudes(), 1);
+  ASSERT_EQ(grid.FieldSize(), 1);
+
+  EXPECT_DOUBLE_EQ(*grid.Longitudes().begin(), 0.0);
+  EXPECT_NEAR(*grid.LongitudeWeights().begin(),
+              2.0 * std::numbers::pi_v<double>,
+              16.0 * std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(*grid.Weights().begin(), 4.0 * std::numbers::pi_v<double>,
+              32.0 * std::numeric_limits<double>::epsilon());
+}
+
+TEST(GaussLegendreGrid, DegreeZeroRealKnownAnswer) {
+  using Real = double;
+  using Complex = std::complex<Real>;
+  using Grid = GaussLegendreGrid<Real, All, All>;
+
+  auto grid = Grid(0, 0, FFTWpp::Estimate);
+  auto field = FFTWpp::vector<Real>(1);
+  auto coefficients = FFTWpp::vector<Complex>(1);
+  field[0] = 3.25;
+
+  grid.ForwardTransformation(0, 0, field, coefficients);
+  const auto expectedCoefficient =
+      field[0] * 2.0 / std::numbers::inv_sqrtpi_v<Real>;
+  EXPECT_NEAR(coefficients[0].real(), expectedCoefficient,
+              32.0 * std::numeric_limits<Real>::epsilon());
+  EXPECT_DOUBLE_EQ(coefficients[0].imag(), 0.0);
+
+  auto reconstructed = FFTWpp::vector<Real>(1);
+  grid.InverseTransformation(0, 0, coefficients, reconstructed);
+  EXPECT_NEAR(reconstructed[0], field[0],
+              32.0 * std::numeric_limits<Real>::epsilon());
+}
+
+TEST(GaussLegendreGrid, DegreeZeroComplexKnownAnswer) {
+  using Real = double;
+  using Complex = std::complex<Real>;
+  using Grid = GaussLegendreGrid<Real, All, All>;
+
+  auto grid = Grid(0, 0, FFTWpp::Estimate);
+  auto field = FFTWpp::vector<Complex>(1);
+  auto coefficients = FFTWpp::vector<Complex>(1);
+  field[0] = Complex(2.5, -0.75);
+
+  grid.ForwardTransformation(0, 0, field, coefficients);
+  const auto expectedCoefficient =
+      field[0] * 2.0 / std::numbers::inv_sqrtpi_v<Real>;
+  EXPECT_NEAR(coefficients[0].real(), expectedCoefficient.real(),
+              32.0 * std::numeric_limits<Real>::epsilon());
+  EXPECT_NEAR(coefficients[0].imag(), expectedCoefficient.imag(),
+              32.0 * std::numeric_limits<Real>::epsilon());
+
+  auto reconstructed = FFTWpp::vector<Complex>(1);
+  grid.InverseTransformation(0, 0, coefficients, reconstructed);
+  EXPECT_NEAR(reconstructed[0].real(), field[0].real(),
+              32.0 * std::numeric_limits<Real>::epsilon());
+  EXPECT_NEAR(reconstructed[0].imag(), field[0].imag(),
+              32.0 * std::numeric_limits<Real>::epsilon());
+}
 
 TEST(GaussLegendreGrid, Coeff2CoeffDoubleR2C) {
   using Scalar = double;

--- a/tests/TestGaussLegendreGrid.cpp
+++ b/tests/TestGaussLegendreGrid.cpp
@@ -70,6 +70,56 @@ TEST(GaussLegendreGrid, DegreeZeroComplexKnownAnswer) {
               32.0 * std::numeric_limits<Real>::epsilon());
 }
 
+TEST(GaussLegendreGrid, DegreeZeroTruncationUsesTheWholeGrid) {
+  using Real = double;
+  using Complex = std::complex<Real>;
+  using Grid = GaussLegendreGrid<Real, All, All>;
+  constexpr auto tolerance = 64.0 * std::numeric_limits<Real>::epsilon();
+
+  auto grid = Grid(2, 0, FFTWpp::Estimate);
+  auto realField = FFTWpp::vector<Real>(grid.FieldSize());
+  auto complexField = FFTWpp::vector<Complex>(grid.FieldSize());
+  for (auto i = std::ptrdiff_t{0}; i < grid.FieldSize(); ++i) {
+    const auto value = static_cast<Real>(i + 1);
+    realField[i] = value;
+    complexField[i] = Complex{value, -0.5 * value};
+  }
+
+  auto expectedReal = Real{};
+  auto expectedComplex = Complex{};
+  auto i = std::ptrdiff_t{0};
+  for (const auto weight : grid.Weights()) {
+    expectedReal += realField[i] * weight;
+    expectedComplex += complexField[i] * weight;
+    ++i;
+  }
+  const auto y00 = std::numbers::inv_sqrtpi_v<Real> / 2.0;
+  expectedReal *= y00;
+  expectedComplex *= y00;
+
+  auto realCoefficient = FFTWpp::vector<Complex>(1);
+  auto complexCoefficient = FFTWpp::vector<Complex>(1);
+  grid.ForwardTransformation(0, 0, realField, realCoefficient);
+  grid.ForwardTransformation(0, 0, complexField, complexCoefficient);
+  EXPECT_NEAR(realCoefficient[0].real(), expectedReal, tolerance);
+  EXPECT_NEAR(realCoefficient[0].imag(), 0.0, tolerance);
+  EXPECT_NEAR(complexCoefficient[0].real(), expectedComplex.real(), tolerance);
+  EXPECT_NEAR(complexCoefficient[0].imag(), expectedComplex.imag(), tolerance);
+
+  const auto constant = Complex{2.0, -0.75};
+  complexCoefficient[0] = constant / y00;
+  realCoefficient[0] = Complex{constant.real() / y00, 0.0};
+  auto reconstructedReal = FFTWpp::vector<Real>(grid.FieldSize());
+  auto reconstructedComplex = FFTWpp::vector<Complex>(grid.FieldSize());
+  grid.InverseTransformation(0, 0, realCoefficient, reconstructedReal);
+  grid.InverseTransformation(0, 0, complexCoefficient, reconstructedComplex);
+  for (auto j = std::ptrdiff_t{0}; j < grid.FieldSize(); ++j) {
+    EXPECT_NEAR(reconstructedReal[j], constant.real(), tolerance);
+    EXPECT_NEAR(reconstructedComplex[j].real(), constant.real(), tolerance);
+    EXPECT_NEAR(reconstructedComplex[j].imag(), constant.imag(), tolerance);
+  }
+}
+
 TEST(GaussLegendreGrid, Coeff2CoeffDoubleR2C) {
   using Scalar = double;
   bool result = Coeff2Coeff<Scalar, All, All>();

--- a/tests/TestGaussLegendreGrid.cpp
+++ b/tests/TestGaussLegendreGrid.cpp
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <numbers>
+#include <stdexcept>
 
 #include "CheckCoeff2Coeff.h"
 
@@ -118,6 +119,41 @@ TEST(GaussLegendreGrid, DegreeZeroTruncationUsesTheWholeGrid) {
     EXPECT_NEAR(reconstructedComplex[j].real(), constant.real(), tolerance);
     EXPECT_NEAR(reconstructedComplex[j].imag(), constant.imag(), tolerance);
   }
+}
+
+TEST(GaussLegendreGrid, RejectsUnsupportedTransformRequests) {
+  using Real = double;
+  using Complex = std::complex<Real>;
+  using Grid = GaussLegendreGrid<Real, All, All>;
+
+  auto onePointGrid = Grid(0, 0, FFTWpp::Estimate);
+  auto onePointField = FFTWpp::vector<Real>(onePointGrid.FieldSize());
+  auto degreeOneCoefficients = FFTWpp::vector<Complex>(3);
+
+  EXPECT_THROW(onePointGrid.ForwardTransformation(
+                   1, 0, onePointField, degreeOneCoefficients),
+               std::invalid_argument);
+  EXPECT_THROW(onePointGrid.InverseTransformation(
+                   1, 0, degreeOneCoefficients, onePointField),
+               std::invalid_argument);
+
+  auto largerGrid = Grid(2, 2, FFTWpp::Estimate);
+  auto largerField = FFTWpp::vector<Real>(largerGrid.FieldSize());
+  auto degreeThreeCoefficients = FFTWpp::vector<Complex>(10);
+  EXPECT_THROW(largerGrid.ForwardTransformation(
+                   3, 0, largerField, degreeThreeCoefficients),
+               std::invalid_argument);
+  EXPECT_THROW(largerGrid.InverseTransformation(
+                   3, 0, degreeThreeCoefficients, largerField),
+               std::invalid_argument);
+  EXPECT_THROW(largerGrid.ForwardTransformation(
+                   1, 2, largerField, degreeOneCoefficients),
+               std::invalid_argument);
+
+  auto scalarGrid = Grid(2, 0, FFTWpp::Estimate);
+  EXPECT_THROW(scalarGrid.ForwardTransformation(
+                   1, 1, largerField, degreeOneCoefficients),
+               std::invalid_argument);
 }
 
 TEST(GaussLegendreGrid, Coeff2CoeffDoubleR2C) {

--- a/tests/TestRealFieldSymmetry.cpp
+++ b/tests/TestRealFieldSymmetry.cpp
@@ -1,0 +1,172 @@
+#include <gtest/gtest.h>
+
+#include <GSHTrans/All>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+
+namespace {
+
+using namespace GSHTrans;
+
+using Real = double;
+using Complex = std::complex<Real>;
+using Grid = GaussLegendreGrid<Real, All, All>;
+
+constexpr std::ptrdiff_t lMax = 5;
+constexpr std::ptrdiff_t n = 2;
+constexpr Real tolerance = 2.0e-11;
+
+template <std::ptrdiff_t N>
+using ReducedExpansion = RealCanonicalComponentExpansion<N, Grid>;
+
+template <std::ptrdiff_t N>
+using FullExpansion = ComplexCanonicalComponentExpansion<N, Grid>;
+
+int Phase(std::ptrdiff_t exponent) {
+  return exponent % 2 == 0 ? 1 : -1;
+}
+
+void ExpectNear(Complex actual, Complex expected) {
+  EXPECT_NEAR(actual.real(), expected.real(), tolerance);
+  EXPECT_NEAR(actual.imag(), expected.imag(), tolerance);
+}
+
+void MakeRealSamples(const Grid& grid, FFTWpp::vector<Real>& realSamples,
+                     FFTWpp::vector<Complex>& complexSamples) {
+  auto i = std::ptrdiff_t{0};
+  for (auto [theta, phi] : grid.Points()) {
+    const auto value =
+        1.25 + 0.4 * std::cos(theta) +
+        0.3 * std::sin(theta) * std::cos(phi) -
+        0.2 * std::sin(2.0 * theta) * std::sin(2.0 * phi) +
+        0.15 * std::cos(3.0 * theta) * std::cos(3.0 * phi) +
+        0.45 * (1.0 + 0.3 * std::cos(theta)) * std::cos(lMax * phi);
+    realSamples[i] = value;
+    complexSamples[i] = Complex{value, 0.0};
+    ++i;
+  }
+}
+
+template <std::ptrdiff_t N>
+void Forward(const Grid& grid, const FFTWpp::vector<Real>& realSamples,
+             const FFTWpp::vector<Complex>& complexSamples,
+             ReducedExpansion<N>& reduced, FullExpansion<N>& full) {
+  auto reducedData = reduced.Data();
+  auto fullData = full.Data();
+  std::ranges::fill(reducedData, Complex{});
+  std::ranges::fill(fullData, Complex{});
+  grid.ForwardTransformation(lMax, N, realSamples, reducedData);
+  grid.ForwardTransformation(lMax, N, complexSamples, fullData);
+}
+
+}  // namespace
+
+TEST(RealFieldSymmetry, ReducedSpectrumMatchesFullPositiveOrders) {
+  auto grid = Grid(lMax, n, FFTWpp::Estimate);
+  auto realSamples = FFTWpp::vector<Real>(grid.FieldSize());
+  auto complexSamples = FFTWpp::vector<Complex>(grid.FieldSize());
+  MakeRealSamples(grid, realSamples, complexSamples);
+
+  auto reducedPlus = ReducedExpansion<n>(grid);
+  auto fullPlus = FullExpansion<n>(grid);
+  auto reducedMinus = ReducedExpansion<-n>(grid);
+  auto fullMinus = FullExpansion<-n>(grid);
+  Forward(grid, realSamples, complexSamples, reducedPlus, fullPlus);
+  Forward(grid, realSamples, complexSamples, reducedMinus, fullMinus);
+
+  for (auto [l, m] : reducedPlus.Indices()) {
+    if (l != lMax || m != lMax) {
+      ExpectNear(reducedPlus[l, m], fullPlus[l, m]);
+      ExpectNear(reducedMinus[l, m], fullMinus[l, m]);
+    }
+  }
+
+  for (auto l : reducedPlus.Degrees()) {
+    const auto plusZonal = reducedPlus[l, 0];
+    const auto minusZonal = reducedMinus[l, 0];
+    EXPECT_NEAR(plusZonal.imag(), 0.0, tolerance);
+    EXPECT_NEAR(minusZonal.imag(), 0.0, tolerance);
+  }
+
+  const auto plusNyquist = reducedPlus[lMax, lMax];
+  const auto minusNyquist = reducedMinus[lMax, lMax];
+  EXPECT_NEAR(plusNyquist.imag(), 0.0, tolerance);
+  EXPECT_NEAR(minusNyquist.imag(), 0.0, tolerance);
+  EXPECT_GT(std::abs(plusNyquist), tolerance);
+  EXPECT_GT(std::abs(minusNyquist), tolerance);
+
+  ExpectNear(fullMinus[lMax, -lMax],
+             static_cast<Real>(Phase(lMax - n)) *
+                 std::conj(plusNyquist));
+  ExpectNear(fullPlus[lMax, -lMax],
+             static_cast<Real>(Phase(lMax + n)) *
+                 std::conj(minusNyquist));
+  ExpectNear(fullPlus[lMax, lMax], Complex{});
+  ExpectNear(fullMinus[lMax, lMax], Complex{});
+}
+
+TEST(RealFieldSymmetry, FullTransformsSatisfyCrossUpperIndexIdentity) {
+  auto grid = Grid(lMax, n, FFTWpp::Estimate);
+  auto realSamples = FFTWpp::vector<Real>(grid.FieldSize());
+  auto complexSamples = FFTWpp::vector<Complex>(grid.FieldSize());
+  MakeRealSamples(grid, realSamples, complexSamples);
+
+  auto reducedPlus = ReducedExpansion<n>(grid);
+  auto reducedMinus = ReducedExpansion<-n>(grid);
+  auto fullPlus = FullExpansion<n>(grid);
+  auto fullMinus = FullExpansion<-n>(grid);
+  Forward(grid, realSamples, complexSamples, reducedPlus, fullPlus);
+  Forward(grid, realSamples, complexSamples, reducedMinus, fullMinus);
+
+  for (auto [l, m] : fullPlus.Indices()) {
+    if (l == lMax && std::abs(m) == lMax) {
+      continue;
+    }
+    const auto expected =
+        static_cast<Real>(Phase(m - n)) * std::conj(fullPlus[l, m]);
+    ExpectNear(fullMinus[l, -m], expected);
+  }
+}
+
+TEST(RealFieldSymmetry, ReducedInverseUsesTheImplicitHermitianPair) {
+  auto grid = Grid(lMax, n, FFTWpp::Estimate);
+  auto realSamples = FFTWpp::vector<Real>(grid.FieldSize());
+  auto complexSamples = FFTWpp::vector<Complex>(grid.FieldSize());
+  MakeRealSamples(grid, realSamples, complexSamples);
+
+  auto reduced = ReducedExpansion<n>(grid);
+  auto unusedFull = FullExpansion<n>(grid);
+  Forward(grid, realSamples, complexSamples, reduced, unusedFull);
+
+  auto positive = FullExpansion<n>(grid);
+  auto negative = FullExpansion<-n>(grid);
+  auto positiveData = positive.Data();
+  auto negativeData = negative.Data();
+  std::ranges::fill(positiveData, Complex{});
+  std::ranges::fill(negativeData, Complex{});
+
+  for (auto [l, m] : reduced.Indices()) {
+    positive[l, m] = reduced[l, m];
+    if (m > 0 && m < lMax) {
+      negative[l, -m] =
+          static_cast<Real>(Phase(m - n)) * std::conj(reduced[l, m]);
+    }
+  }
+
+  auto reducedField = FFTWpp::vector<Real>(grid.FieldSize());
+  auto positiveField = FFTWpp::vector<Complex>(grid.FieldSize());
+  auto negativeField = FFTWpp::vector<Complex>(grid.FieldSize());
+  auto reducedData = reduced.Data();
+  grid.InverseTransformation(lMax, n, reducedData, reducedField);
+  grid.InverseTransformation(lMax, n, positiveData, positiveField);
+  grid.InverseTransformation(lMax, -n, negativeData, negativeField);
+
+  for (auto i = std::ptrdiff_t{0}; i < grid.FieldSize(); ++i) {
+    const auto hermitianValue = positiveField[i] + negativeField[i];
+    EXPECT_NEAR(hermitianValue.imag(), 0.0, tolerance);
+    EXPECT_NEAR(reducedField[i], hermitianValue.real(), tolerance);
+  }
+}

--- a/tests/TestWigner.cpp
+++ b/tests/TestWigner.cpp
@@ -1,7 +1,42 @@
 #include <gtest/gtest.h>
 
+#include <array>
+
 #include "CheckAdditionTheorem.h"
 #include "CheckLegendre.h"
+
+namespace {
+
+void CheckSingleUpperIndexAccess(std::ptrdiff_t n) {
+  using namespace GSHTrans;
+
+  constexpr std::ptrdiff_t lMax = 5;
+  constexpr std::ptrdiff_t mMax = 3;
+
+  auto singleAngle =
+      Wigner<double, FourPi, All, Single, Single>(lMax, mMax, n, 0.7);
+  auto explicitSingleAngle = singleAngle[n, 0];
+  for (auto l : singleAngle.Degrees()) {
+    for (auto m : explicitSingleAngle[l].Orders()) {
+      EXPECT_DOUBLE_EQ(singleAngle[l][m], explicitSingleAngle[l][m]);
+    }
+  }
+
+  const auto angles = std::array{0.2, 0.7, 1.3};
+  auto multipleAngles =
+      Wigner<double, FourPi, All, Single, Multiple>(lMax, mMax, n, angles);
+  for (auto iTheta : multipleAngles.AngleIndices()) {
+    auto implicitView = multipleAngles[iTheta];
+    auto explicitView = multipleAngles[n, iTheta];
+    for (auto l : explicitView.Degrees()) {
+      for (auto m : explicitView[l].Orders()) {
+        EXPECT_DOUBLE_EQ(implicitView[l][m], explicitView[l][m]);
+      }
+    }
+  }
+}
+
+}  // namespace
 
 // Compare values for n = 0 to the std library function.
 TEST(Wigner, CheckLegendreDouble) {
@@ -23,4 +58,17 @@ TEST(Wigner, CheckAdditionTheoremDouble) {
 TEST(Wigner, CheckAdditionTheoremLongDouble) {
   int i = CheckAdditionTheorem<long double>();
   EXPECT_EQ(i, 0);
+}
+
+TEST(Wigner, SinglePositiveUpperIndexAccess) {
+  CheckSingleUpperIndexAccess(2);
+}
+
+TEST(Wigner, SingleNegativeUpperIndexAccess) {
+  CheckSingleUpperIndexAccess(-2);
+}
+
+TEST(Wigner, SingleMaximumUpperIndexAccess) {
+  CheckSingleUpperIndexAccess(5);
+  CheckSingleUpperIndexAccess(-5);
 }


### PR DESCRIPTION
## Summary

This PR fixes several correctness, lifetime, and Release-build safety problems in
the Wigner, Gauss–Legendre transform, canonical field, and canonical expansion
implementations.

It also adds focused regression coverage for the affected numerical conventions
and previously uninstantiated template operations.

## Why these changes are needed

Several operations either produced incorrect numerical results or depended on
Debug-only assertions for safety:

- `Wigner<..., Single, ...>` convenience accessors incorrectly selected `n = 0`
  instead of the configured upper index.
- Degree-zero grids had no longitude samples and incorrect transform
  normalization.
- Some canonical field operations used invalid access syntax or could retain
  dangling references to callable objects.
- Canonical expansion indexing and storage did not correctly represent both
  real-valued and complex-valued transforms.
- Assignment and compound operations could index incompatible fields or
  expansions when assertions were disabled.
- Transform requests above the grid degree could silently ignore coefficients
  or leave output data unwritten.

## Main changes

### Wigner and Gauss–Legendre transforms

- Use the configured upper index in `Single`-`n` Wigner accessors, including
  positive, negative, and `|n| = lMax` cases.
- Give an `lMax = 0` grid one longitude with weight `2π`.
- Correct degree-zero forward and inverse normalization to match
  `Y00 = 1 / sqrt(4π)`.
- Preserve valid degree-zero truncation when using a grid with a larger maximum
  degree.
- Reject negative transform degrees, degrees above the grid maximum, and upper
  indices unsupported by the requested degree or grid.

### Canonical fields and expressions

- Correct compound operations to use indexed field access.
- Materialize lazy expressions using the field’s grid constructor.
- Store unary and scalar callable objects by value with forwarding and decayed
  CTAD types, preventing dangling callable references.
- Make callable constraints consistent with const expression evaluation.
- Make assignment copy values without rebinding the destination grid.
- Reject incompatible field sizes with `std::invalid_argument` in assignment
  and compound operations.
- Explicitly delete unusable default constructors.

### Canonical expansions

- Replace ambiguous inheritance from `GSHIndices` with composition.
- Restore indexing, iteration, assignment, compound arithmetic, and const and
  mutable data access.
- Preserve complex coefficient storage for both real-valued and complex-valued
  expansions.
- For `RealValued`, store only the reduced `m >= 0` spectrum; for
  `ComplexValued`, store all orders.
- Preserve the destination grid during copy and move assignment.
- Reject incompatible expansion sizes before indexing.

### Real-field convention

`RealValued` describes a reduced spectral representation of real grid samples;
it does not mean that every stored coefficient is real.

The tests verify that the reduced coefficients agree with the nonnegative-order
part of a full complex transform and satisfy the GSH reality relation

a(l,-m,-n) = (-1)^(m-n) conjugate(a(l,m,n)).

The `m = 0` and Nyquist cases are tested explicitly.

## API effects

- Existing transform, field, expansion, and alias names are preserved.
- Real-valued expansions intentionally expose complex coefficients for
  `m >= 0`.
- Invalid size and transform requests now throw `std::invalid_argument` in all
  build modes.
- Unusable default constructors are now explicitly deleted.

## Testing

The branch adds focused tests for:

- nonzero and boundary `Single`-`n` Wigner access;
- degree-zero geometry, normalization, truncation, and invalid requests;
- real and complex field arithmetic and expression materialization;
- callable ownership and CTAD;
- field and expansion assignment and compound-operation size checks;
- real and complex expansion storage and indexing;
- reduced real-spectrum and cross-`n` symmetry.

Before synchronizing with the latest upstream `main`:

- all 32 tests passed across three repeated Debug runs;
- all 32 tests passed in Release with AddressSanitizer and UBSan;
- all examples and tests built successfully;
- `git diff --check` passed.